### PR TITLE
FEAT : CDE-46-exclusion-de-packages-ou-de-providers :

### DIFF
--- a/src/main/java/fr/abes/bestppn/kafka/KafkaWorkInProgress.java
+++ b/src/main/java/fr/abes/bestppn/kafka/KafkaWorkInProgress.java
@@ -24,6 +24,8 @@ public class KafkaWorkInProgress {
 
     private boolean isForced;
 
+    private boolean isBypassed;
+
     private ExecutionReport executionReport = new ExecutionReport();
 
     private final PackageKbartDto mailAttachment;
@@ -42,8 +44,9 @@ public class KafkaWorkInProgress {
 
     private final List<LigneKbartDto> ppnFromKbartToCreate;
 
-    public KafkaWorkInProgress(boolean isForced) {
+    public KafkaWorkInProgress(boolean isForced, boolean isBypassed) {
         this.isForced = isForced;
+        this.isBypassed = isBypassed;
         this.mailAttachment = new PackageKbartDto();
         this.isOnError = new AtomicBoolean(false);
         this.nbLignesTraitees = new AtomicInteger(0);

--- a/src/main/java/fr/abes/bestppn/utils/Utils.java
+++ b/src/main/java/fr/abes/bestppn/utils/Utils.java
@@ -78,6 +78,9 @@ public class Utils {
             if (filename.contains("_FORCE")) {
                 String tempsStr =  filename.substring(0, filename.indexOf("_FORCE"));
                 return tempsStr.substring(tempsStr.indexOf('_') + 1, tempsStr.lastIndexOf('_'));
+            } else if (filename.contains("_BYPASS")) {
+                String tempStr = filename.substring(0, filename.indexOf("_BYPASS"));
+                return tempStr.substring(tempStr.indexOf('_') + 1, tempStr.lastIndexOf('_'));
             } else {
                 return filename.substring(filename.indexOf('_') + 1, filename.lastIndexOf('_'));
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,7 +36,7 @@ topic.name.target.endoftraitment=bestppn.endoftraitment
 topic.name.source.kbart=bacon.kbart.toload
 topic.name.source.kbart.errors=bacon.kbart.toload.errors
 topic.name.source.nbLines=bacon.kbart.toload.nbLines
-
+topic.name.target.kbart.bypass.toload=bacon.kbart.bypass.toload
 
 spring.jpa.open-in-view=false
 


### PR DESCRIPTION
     - ajout d'un paramètre topic.name.target.kbart.bypass.toload dans le application.properties
     - ajout d'un paramètre isBypassed dans KafkaWorkInProgress.java
     - ajout d'un contrôle sur _BYPASS dans la méthode extractPackageName() de Utils.java
     - ajout d'un contrôle isBypassed dans la méthode processConsumerRecord() de KbartService.java
     - ajout d'une variable topicKbartBypassToLoad, ajout d'une méthode sendToTopic(), ajout d'une méthode sendBypassToLoad() et adaptation de la méthode sendKbart() dans TopicProducer.java
     - adaptation des appels des méthodes avec ajout du boolean isBypassed dans TopicConsumer.java