### PR TITLE
Dans les 3 producers envoyant les informations dans les topics :

### DIFF
--- a/src/main/java/fr/abes/bestppn/dto/wscall/PpnDto.java
+++ b/src/main/java/fr/abes/bestppn/dto/wscall/PpnDto.java
@@ -1,2 +1,0 @@
-package fr.abes.bestppn.dto.wscall;public class PpnDto {
-}

--- a/src/main/java/fr/abes/bestppn/dto/wscall/PpnDto.java
+++ b/src/main/java/fr/abes/bestppn/dto/wscall/PpnDto.java
@@ -1,0 +1,2 @@
+package fr.abes.bestppn.dto.wscall;public class PpnDto {
+}

--- a/src/main/java/fr/abes/bestppn/kafka/TopicProducer.java
+++ b/src/main/java/fr/abes/bestppn/kafka/TopicProducer.java
@@ -132,8 +132,9 @@ public class TopicProducer {
      */
     @Transactional(transactionManager = "kafkaTransactionManagerKbartImprime")
     public void sendPrintNotice(List<LigneKbartImprime> ligneKbartImprimes, String filename) {
+        Integer nbLigneTotal = ligneKbartImprimes.size();
         for (LigneKbartImprime ppnToCreate : ligneKbartImprimes) {
-            sendNoticeImprime(ppnToCreate, topicNoticeImprimee, filename);
+            sendNoticeImprime(ppnToCreate, topicNoticeImprimee, filename, nbLigneTotal);
         }
         if (!ligneKbartImprimes.isEmpty())
             log.debug("message envoyé vers {}", topicNoticeImprimee);
@@ -147,12 +148,13 @@ public class TopicProducer {
      */
     @Transactional(transactionManager = "kafkaTransactionManagerKbartConnect")
     public void sendPpnExNihilo(List<LigneKbartDto> ppnFromKbartToCreate, ProviderPackage provider, String filename) {
+        Integer nbLigneTotal = ppnFromKbartToCreate.size();
         for (LigneKbartDto ligne : ppnFromKbartToCreate) {
             ligne.setIdProviderPackage(provider.getIdProviderPackage());
             ligne.setProviderPackagePackage(provider.getPackageName());
             ligne.setProviderPackageDateP(provider.getDateP());
             ligne.setProviderPackageIdtProvider(provider.getProviderIdtProvider());
-            sendNoticeExNihilo(ligne, topicKbartPpnToCreate, filename);
+            sendNoticeExNihilo(ligne, topicKbartPpnToCreate, filename, nbLigneTotal);
         }
         if (!ppnFromKbartToCreate.isEmpty())
             log.debug("message envoyé vers {}", topicKbartPpnToCreate);
@@ -162,12 +164,14 @@ public class TopicProducer {
      * Méthode envoyant un objet de notice imprimé sur un topic Kafka
      * @param ligneKbartDto : ligne contenant la ligne kbart, et le provider
      * @param topic : topic d'envoi de la ligne
-     * @param key : clé kafka de la ligne correspondant au nom de fichier
+     * @param filemame : clé kafka de la ligne correspondant au nom de fichier
      */
-    private void sendNoticeExNihilo(LigneKbartDto ligneKbartDto, String topic, String key) {
+    private void sendNoticeExNihilo(LigneKbartDto ligneKbartDto, String topic, String filemame, Integer nbLignesTotal) {
+        List<Header> headerList = new ArrayList<>();
         LigneKbartConnect ligne = utilsMapper.map(ligneKbartDto, LigneKbartConnect.class);
         try {
-            ProducerRecord<String, LigneKbartConnect> record = new ProducerRecord<>(topic, null, key, ligne);
+            headerList.add(new RecordHeader("nbLinesTotal", String.valueOf(nbLignesTotal).getBytes()));
+            ProducerRecord<String, LigneKbartConnect> record = new ProducerRecord<>(topic, null, filemame, ligne, headerList);
             final SendResult<String, LigneKbartConnect> result = kafkaTemplateConnect.send(record).get();
             logEnvoi(result, record);
         } catch (Exception e) {
@@ -180,11 +184,14 @@ public class TopicProducer {
      * Méthode envoyant un objet de notice imprimé sur un topic Kafka
      * @param ligne : ligne contenant la ligne kbart, le ppn de la notice imprimée et le provider
      * @param topic : topic d'envoi de la ligne
-     * @param key : clé kafka de la ligne correspondant au nom du fichier
+     * @param filename : clé kafka de la ligne correspondant au nom du fichier
+     * @param nbLignesTotal : nombre de lignes totales du fichier
      */
-    private void sendNoticeImprime(LigneKbartImprime ligne, String topic, String key) {
+    private void sendNoticeImprime(LigneKbartImprime ligne, String topic, String filename, Integer nbLignesTotal) {
+        List<Header> headerList = new ArrayList<>();
+        headerList.add(new RecordHeader("nbLinesTotal", String.valueOf(nbLignesTotal).getBytes()));
         try {
-            ProducerRecord<String, LigneKbartImprime> record = new ProducerRecord<>(topic, null, key, ligne);
+            ProducerRecord<String, LigneKbartImprime> record = new ProducerRecord<>(topic, null, filename, ligne, headerList);
             final SendResult<String, LigneKbartImprime> result = kafkaTemplateImprime.send(record).get();
             logEnvoi(result, record);
         } catch (Exception e) {


### PR DESCRIPTION
bacon.kbart.withppn.toload
bacon.kbart.sudoc.tocreate.exnihilo
bacon.kbart.sudoc.imprime.tocreate

Ajouter dans le header le nombre total de lignes envoyé pour un fichier donné. Ajouter la clé correspondant au nom de fichier quand c’est nécessaire.