### PR TITLE
fix(service): correct null check for resultWithTypeImprime and result…

### DIFF
--- a/src/main/java/fr/abes/bestppn/service/BestPpnService.java
+++ b/src/main/java/fr/abes/bestppn/service/BestPpnService.java
@@ -102,11 +102,11 @@ public class BestPpnService {
                 setScoreToEveryPpnFromResultWS(resultWithTypeElectronique, kbart.getTitleUrl(), this.scorePrintId2PpnElect, ppnElecScoredList, ppnPrintResultList);
             }
             ResultWsSudocDto resultWithTypeImprime = resultCallWs.getPpnWithTypeImprime();
-            if (resultWithTypeElectronique != null && !resultWithTypeImprime.getPpns().isEmpty()) {
+            if (resultWithTypeImprime != null && !resultWithTypeImprime.getPpns().isEmpty()) {
                 setScoreToEveryPpnFromResultWS(resultWithTypeImprime, kbart.getTitleUrl(), this.scoreErrorType, ppnElecScoredList, ppnPrintResultList);
             }
             ResultWsSudocDto resultWithTypeAutre = resultCallWs.getPpnWithTypeAutre().changePpnWithTypeAutreToTypeElectronique();
-            if (resultWithTypeElectronique != null && !resultWithTypeAutre.getPpns().isEmpty()) {
+            if (resultWithTypeAutre != null && !resultWithTypeAutre.getPpns().isEmpty()) {
                 setScoreToEveryPpnFromResultWS(resultWithTypeAutre, kbart.getTitleUrl(), this.scoreErrorType, ppnElecScoredList, ppnPrintResultList);
             }
         } catch (RestClientException ex) {


### PR DESCRIPTION
…WithTypeAutre

Fixed improper null checks in `BestPpnService` for `resultWithTypeImprime` and `resultWithTypeAutre`, ensuring accurate condition evaluation and preventing potential `NullPointerException`.