### PR TITLE
Promotion test : déployer SOA-501

### DIFF
--- a/docs/superpowers/plans/2026-07-23-soa-501-departage-bestppn-implementation.md
+++ b/docs/superpowers/plans/2026-07-23-soa-501-departage-bestppn-implementation.md
@@ -1,0 +1,2193 @@
+# SOA-501 — Départage des PPN ex aequo Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Départager de manière conservatrice les PPN électroniques ayant le même score maximal en appliquant successivement SUPPORT, DIFFUSEUR, VOLUME et ANNÉE.
+
+**Architecture:** `BestPpnService` conserve les recherches et les scores actuels, puis délègue uniquement les égalités maximales à `BestPpnTieBreakerService`. Le nouveau service charge chaque notice XML une seule fois, confie l’extraction à `CandidateMetadataExtractor`, construit une clé lexicographique et ne renvoie un PPN que si le meilleur candidat est unique et sans contradiction forte.
+
+**Tech Stack:** Java 21, Spring Boot 3.5.6, JUnit 5, Mockito, Maven, données UNIMARC XML de la base APISUDOC.
+
+## Global Constraints
+
+- Dépôt modifié : `best-ppn-api` uniquement.
+- Branche existante : `SOA-501-affiner-departage-bestppn`, créée depuis `origin/develop`.
+- Aucun changement du contrat JSON ni du code de `sudoc-api`.
+- Aucun changement des scores existants : 10, 8, 6, 15 et 20.
+- Aucun changement de l’enchaînement `dat2ppn`.
+- L’arbitrage ne s’exécute que pour plusieurs PPN électroniques au score maximal.
+- Ordre lexicographique obligatoire : score actuel, SUPPORT, DIFFUSEUR, VOLUME, ANNÉE.
+- SUPPORT physique, VOLUME explicitement incompatible et ANNÉE explicitement incompatible sont des contradictions fortes.
+- Le rang DIFFUSEUR 0 ne constitue pas à lui seul une contradiction forte.
+- Le booléen agrégé `providerPresent` n’est pas utilisé pour calculer le rang DIFFUSEUR.
+- Pour une publication en série, seuls le score actuel et SUPPORT sont discriminants.
+- Une notice absente, supprimée ou illisible conserve l’égalité.
+- Aucune nouvelle dépendance Maven.
+- Les titres et descriptions de commits sont rédigés en français.
+- Les fichiers Avro `src/main/java/fr/abes/LigneKbartConnect.java` et `src/main/java/fr/abes/LigneKbartImprime.java`, régénérés par Maven, ne sont jamais ajoutés aux commits SOA-501.
+
+---
+
+## File Structure
+
+### Fichiers créés
+
+- `src/main/java/fr/abes/bestppn/model/tiebreak/AccessMode.java` : mode d’accès explicite extrait d’une notice.
+- `src/main/java/fr/abes/bestppn/model/tiebreak/CandidateMetadata.java` : métadonnées normalisées et preuves issues d’une notice.
+- `src/main/java/fr/abes/bestppn/model/tiebreak/CandidateDecisionKey.java` : clé lexicographique et contrôle des contradictions fortes.
+- `src/main/java/fr/abes/bestppn/model/tiebreak/TieBreakDecision.java` : résultat résolu ou indécidable avec clés et motif.
+- `src/main/java/fr/abes/bestppn/utils/TieBreakNormalizer.java` : normalisation textuelle, années et volumes.
+- `src/main/java/fr/abes/bestppn/service/CandidateMetadataExtractor.java` : extraction pure des zones UNIMARC.
+- `src/main/java/fr/abes/bestppn/service/BestPpnTieBreakerService.java` : chargement XML, calcul des rangs, cascade et journalisation.
+- `src/test/java/fr/abes/bestppn/utils/TieBreakNormalizerTest.java` : tests de normalisation.
+- `src/test/java/fr/abes/bestppn/model/tiebreak/CandidateDecisionKeyTest.java` : tests de comparaison et veto.
+- `src/test/java/fr/abes/bestppn/service/CandidateMetadataExtractorTest.java` : tests des zones XML.
+- `src/test/java/fr/abes/bestppn/service/BestPpnTieBreakerServiceTest.java` : tests unitaires des règles d’arbitrage.
+- `src/test/java/fr/abes/bestppn/service/BestPpnServiceTieBreakTest.java` : tests de l’intégration au calcul actuel.
+- `src/test/java/fr/abes/bestppn/service/BestPpnTieBreakerFlowTest.java` : non-régression du flux XML complet.
+
+### Fichiers modifiés
+
+- `src/main/java/fr/abes/bestppn/service/BestPpnService.java:40-54` : remplacer la dépendance XML directe par le service d’arbitrage.
+- `src/main/java/fr/abes/bestppn/service/BestPpnService.java:81` : transmettre le provider au calcul final.
+- `src/main/java/fr/abes/bestppn/service/BestPpnService.java:199-247` : appeler l’arbitrage avant l’erreur d’égalité actuelle.
+- `src/test/java/fr/abes/bestppn/service/BestPpnServiceTest.java:35-51` : fournir le mock du nouveau service.
+- `src/test/java/fr/abes/bestppn/service/BestPpnServiceTest.java:358-401` : adapter la signature publique testée.
+
+---
+
+### Task 1: Primitives de décision et normalisation
+
+**Files:**
+
+- Create: `src/main/java/fr/abes/bestppn/model/tiebreak/AccessMode.java`
+- Create: `src/main/java/fr/abes/bestppn/model/tiebreak/CandidateMetadata.java`
+- Create: `src/main/java/fr/abes/bestppn/model/tiebreak/CandidateDecisionKey.java`
+- Create: `src/main/java/fr/abes/bestppn/model/tiebreak/TieBreakDecision.java`
+- Create: `src/main/java/fr/abes/bestppn/utils/TieBreakNormalizer.java`
+- Test: `src/test/java/fr/abes/bestppn/utils/TieBreakNormalizerTest.java`
+- Test: `src/test/java/fr/abes/bestppn/model/tiebreak/CandidateDecisionKeyTest.java`
+
+**Interfaces:**
+
+- Consumes: chaînes brutes KBART ou UNIMARC.
+- Produces: `TieBreakNormalizer.normalizeText(String)`, `extractYear(String)`, `extractDate1From100(String)`, `extractYears(String)`, `normalizeVolume(String)`, `extractVolumeFromTitle(String)` et `containsWord(String, String)`.
+- Produces: `CandidateDecisionKey implements Comparable<CandidateDecisionKey>`.
+- Produces: `TieBreakDecision.selected(...)`, `TieBreakDecision.unresolved(...)` et `TieBreakDecision.resolved()`.
+
+- [ ] **Step 1: Write the failing normalization tests**
+
+Créer `src/test/java/fr/abes/bestppn/utils/TieBreakNormalizerTest.java` :
+
+```java
+package fr.abes.bestppn.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TieBreakNormalizerTest {
+
+    @Test
+    void normaliseTexteSansPerdreLesChiffres() {
+        assertEquals("edition numero 2", TieBreakNormalizer.normalizeText("  Édition, numéro 2  "));
+    }
+
+    @Test
+    void normaliseLesVariantesDeVolume() {
+        assertEquals(Optional.of("2"), TieBreakNormalizer.normalizeVolume("02"));
+        assertEquals(Optional.of("2"), TieBreakNormalizer.normalizeVolume("Tome 2"));
+        assertEquals(Optional.of("2"), TieBreakNormalizer.normalizeVolume("Vol. 2"));
+        assertEquals(Optional.of("2"), TieBreakNormalizer.normalizeVolume("Part II"));
+        assertEquals(Optional.empty(), TieBreakNormalizer.normalizeVolume("IIII"));
+    }
+
+    @Test
+    void extraitUnVolumeUniquementAvecUnPrefixeDansLeTitre() {
+        assertEquals(Optional.of("12"), TieBreakNormalizer.extractVolumeFromTitle("Traité pratique, volume XII"));
+        assertEquals(Optional.empty(), TieBreakNormalizer.extractVolumeFromTitle("Les douze travaux"));
+    }
+
+    @Test
+    void extraitLaDate1DeLaZone100EtNonLaDateDeSaisie() {
+        assertEquals(OptionalInt.of(2021), TieBreakNormalizer.extractDate1From100("20240723d2021    m  y0frey50      ba"));
+        assertEquals(OptionalInt.empty(), TieBreakNormalizer.extractDate1From100("valeur courte"));
+    }
+
+    @Test
+    void extraitLesAnneesDesMentionsDePublication() {
+        assertEquals(OptionalInt.of(2021), TieBreakNormalizer.extractYear("DL 2021"));
+        assertEquals(Set.of(2020, 2021), TieBreakNormalizer.extractYears("cop. 2020-2021"));
+    }
+
+    @Test
+    void reconnaitUnCodeProviderCommeMotComplet() {
+        assertTrue(TieBreakNormalizer.containsWord("diffusion cairn info", "cairn"));
+        assertFalse(TieBreakNormalizer.containsWord("diffusion cairninfo", "cairn"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the normalization test to verify it fails**
+
+Run:
+
+```powershell
+mvn "-Dtest=TieBreakNormalizerTest" test
+```
+
+Expected: `FAIL` pendant `testCompile`, car `TieBreakNormalizer` n’existe pas.
+
+- [ ] **Step 3: Implement the normalizer**
+
+Créer `src/main/java/fr/abes/bestppn/utils/TieBreakNormalizer.java` :
+
+```java
+package fr.abes.bestppn.utils;
+
+import java.text.Normalizer;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class TieBreakNormalizer {
+    private static final Pattern DIACRITICS = Pattern.compile("\\p{M}+");
+    private static final Pattern NON_ALPHANUMERIC = Pattern.compile("[^\\p{L}\\p{N}]+");
+    private static final Pattern SPACES = Pattern.compile("\\s+");
+    private static final Pattern YEAR = Pattern.compile("(?<!\\d)(?:18|19|20|21)\\d{2}(?!\\d)");
+    private static final Pattern VOLUME = Pattern.compile(
+            "^(?:(?:tome|volume|vol|partie|part|band)\\s*)?([0-9]+|[ivxlcdm]+)(?:\\s.*)?$",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern VOLUME_IN_TITLE = Pattern.compile(
+            "(?:^|\\s)(?:tome|volume|vol|partie|part|band)\\s+([0-9]+|[ivxlcdm]+)(?:\\s|$)",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern VALID_ROMAN = Pattern.compile("[IVXLCDM]+");
+
+    private TieBreakNormalizer() {
+    }
+
+    public static String normalizeText(String value) {
+        if (value == null) {
+            return "";
+        }
+        String decomposed = Normalizer.normalize(value, Normalizer.Form.NFD);
+        String withoutDiacritics = DIACRITICS.matcher(decomposed).replaceAll("");
+        String withoutPunctuation = NON_ALPHANUMERIC.matcher(withoutDiacritics).replaceAll(" ");
+        return SPACES.matcher(withoutPunctuation.toLowerCase(Locale.ROOT).trim()).replaceAll(" ");
+    }
+
+    public static OptionalInt extractYear(String value) {
+        Matcher matcher = YEAR.matcher(value == null ? "" : value);
+        return matcher.find() ? OptionalInt.of(Integer.parseInt(matcher.group())) : OptionalInt.empty();
+    }
+
+    public static OptionalInt extractDate1From100(String value) {
+        if (value == null || value.length() < 13) {
+            return OptionalInt.empty();
+        }
+        String date1 = value.substring(9, 13);
+        return date1.matches("(?:18|19|20|21)\\d{2}")
+                ? OptionalInt.of(Integer.parseInt(date1))
+                : OptionalInt.empty();
+    }
+
+    public static Set<Integer> extractYears(String value) {
+        Set<Integer> years = new LinkedHashSet<>();
+        Matcher matcher = YEAR.matcher(value == null ? "" : value);
+        while (matcher.find()) {
+            years.add(Integer.parseInt(matcher.group()));
+        }
+        return Set.copyOf(years);
+    }
+
+    public static Optional<String> normalizeVolume(String value) {
+        String normalized = normalizeText(value);
+        Matcher matcher = VOLUME.matcher(normalized);
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
+        String token = matcher.group(1);
+        if (token.chars().allMatch(Character::isDigit)) {
+            return Optional.of(Integer.toString(Integer.parseInt(token)));
+        }
+        return romanToArabic(token).map(String::valueOf);
+    }
+
+    public static Optional<String> extractVolumeFromTitle(String title) {
+        Matcher matcher = VOLUME_IN_TITLE.matcher(normalizeText(title));
+        return matcher.find() ? normalizeVolume(matcher.group(1)) : Optional.empty();
+    }
+
+    public static boolean containsWord(String text, String word) {
+        String normalizedText = normalizeText(text);
+        String normalizedWord = normalizeText(word);
+        if (normalizedWord.isBlank()) {
+            return false;
+        }
+        Pattern completeWord = Pattern.compile("(^|\\s)" + Pattern.quote(normalizedWord) + "($|\\s)");
+        return completeWord.matcher(normalizedText).find();
+    }
+
+    private static Optional<Integer> romanToArabic(String value) {
+        String roman = value.toUpperCase(Locale.ROOT);
+        if (!VALID_ROMAN.matcher(roman).matches()) {
+            return Optional.empty();
+        }
+        int total = 0;
+        int previous = 0;
+        for (int index = roman.length() - 1; index >= 0; index--) {
+            int current = romanValue(roman.charAt(index));
+            total += current < previous ? -current : current;
+            previous = current;
+        }
+        return total > 0 && toRoman(total).equals(roman) ? Optional.of(total) : Optional.empty();
+    }
+
+    private static int romanValue(char value) {
+        return switch (value) {
+            case 'I' -> 1;
+            case 'V' -> 5;
+            case 'X' -> 10;
+            case 'L' -> 50;
+            case 'C' -> 100;
+            case 'D' -> 500;
+            case 'M' -> 1000;
+            default -> 0;
+        };
+    }
+
+    private static String toRoman(int value) {
+        int[] arabic = {1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1};
+        String[] roman = {"M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"};
+        StringBuilder result = new StringBuilder();
+        int remaining = value;
+        for (int index = 0; index < arabic.length; index++) {
+            while (remaining >= arabic[index]) {
+                result.append(roman[index]);
+                remaining -= arabic[index];
+            }
+        }
+        return result.toString();
+    }
+}
+```
+
+- [ ] **Step 4: Run the normalization tests**
+
+Run:
+
+```powershell
+mvn "-Dtest=TieBreakNormalizerTest" test
+```
+
+Expected: `Tests run: 6, Failures: 0, Errors: 0` puis `BUILD SUCCESS`.
+
+- [ ] **Step 5: Write the failing decision-model tests**
+
+Créer `src/test/java/fr/abes/bestppn/model/tiebreak/CandidateDecisionKeyTest.java` :
+
+```java
+package fr.abes.bestppn.model.tiebreak;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CandidateDecisionKeyTest {
+
+    @Test
+    void compareDansLOrdreScoreSupportDiffuseurVolumeAnnee() {
+        CandidateDecisionKey supportFort = new CandidateDecisionKey(10, 2, 0, 0, 0);
+        CandidateDecisionKey diffuseurFort = new CandidateDecisionKey(10, 1, 2, 3, 3);
+        CandidateDecisionKey scoreFort = new CandidateDecisionKey(11, 0, 0, 0, 0);
+
+        assertTrue(supportFort.compareTo(diffuseurFort) > 0);
+        assertTrue(scoreFort.compareTo(supportFort) > 0);
+    }
+
+    @Test
+    void identifieUniquementLesContradictionsFortes() {
+        assertTrue(new CandidateDecisionKey(10, 0, 2, 3, 3).hasStrongContradiction());
+        assertTrue(new CandidateDecisionKey(10, 2, 2, 0, 3).hasStrongContradiction());
+        assertTrue(new CandidateDecisionKey(10, 2, 2, 3, 0).hasStrongContradiction());
+        assertFalse(new CandidateDecisionKey(10, 2, 0, 3, 3).hasStrongContradiction());
+    }
+
+    @Test
+    void exposeUneDecisionResolueOuIndecidable() {
+        CandidateDecisionKey key = new CandidateDecisionKey(10, 2, 1, 1, 1);
+        TieBreakDecision selected = TieBreakDecision.selected("123456789", Map.of("123456789", key), "SUPPORT");
+        TieBreakDecision unresolved = TieBreakDecision.unresolved(Map.of("123456789", key), "égalité");
+
+        assertTrue(selected.resolved());
+        assertEquals("123456789", selected.selectedPpn());
+        assertFalse(unresolved.resolved());
+        assertNull(unresolved.selectedPpn());
+    }
+
+    @Test
+    void detecteDesAnneesSudocContradictoires() {
+        CandidateMetadata metadata = new CandidateMetadata(
+                "123456789",
+                AccessMode.ONLINE,
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                Set.of(2021),
+                Set.of(2020, 2021),
+                List.of(),
+                false);
+
+        assertTrue(metadata.hasContradictoryYears());
+    }
+}
+```
+
+- [ ] **Step 6: Run the decision-model test to verify it fails**
+
+Run:
+
+```powershell
+mvn "-Dtest=CandidateDecisionKeyTest" test
+```
+
+Expected: `FAIL` pendant `testCompile`, car les types `model.tiebreak` n’existent pas.
+
+- [ ] **Step 7: Implement the decision models**
+
+Créer `src/main/java/fr/abes/bestppn/model/tiebreak/AccessMode.java` :
+
+```java
+package fr.abes.bestppn.model.tiebreak;
+
+public enum AccessMode {
+    ONLINE,
+    PHYSICAL,
+    UNKNOWN
+}
+```
+
+Créer `src/main/java/fr/abes/bestppn/model/tiebreak/CandidateMetadata.java` :
+
+```java
+package fr.abes.bestppn.model.tiebreak;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public record CandidateMetadata(
+        String ppn,
+        AccessMode accessMode,
+        Set<String> distributors,
+        Set<String> volumeNumbers,
+        Set<String> partTitles,
+        Set<Integer> yearsFrom100,
+        Set<Integer> yearsFrom214,
+        List<String> evidence,
+        boolean unreadable) {
+
+    public CandidateMetadata {
+        distributors = immutableSet(distributors);
+        volumeNumbers = immutableSet(volumeNumbers);
+        partTitles = immutableSet(partTitles);
+        yearsFrom100 = immutableSet(yearsFrom100);
+        yearsFrom214 = immutableSet(yearsFrom214);
+        evidence = evidence == null ? List.of() : List.copyOf(evidence);
+    }
+
+    public static CandidateMetadata unreadable(String ppn, String reason) {
+        return new CandidateMetadata(
+                ppn,
+                AccessMode.UNKNOWN,
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                List.of(reason),
+                true);
+    }
+
+    public Set<Integer> allYears() {
+        Set<Integer> years = new LinkedHashSet<>(yearsFrom100);
+        years.addAll(yearsFrom214);
+        return Collections.unmodifiableSet(years);
+    }
+
+    public boolean hasContradictoryYears() {
+        return allYears().size() > 1;
+    }
+
+    private static <T> Set<T> immutableSet(Set<T> values) {
+        return values == null
+                ? Set.of()
+                : Collections.unmodifiableSet(new LinkedHashSet<>(values));
+    }
+}
+```
+
+Créer `src/main/java/fr/abes/bestppn/model/tiebreak/CandidateDecisionKey.java` :
+
+```java
+package fr.abes.bestppn.model.tiebreak;
+
+import java.util.Comparator;
+
+public record CandidateDecisionKey(
+        int currentScore,
+        int supportRank,
+        int distributorRank,
+        int volumeRank,
+        int yearRank) implements Comparable<CandidateDecisionKey> {
+
+    private static final Comparator<CandidateDecisionKey> COMPARATOR =
+            Comparator.comparingInt(CandidateDecisionKey::currentScore)
+                    .thenComparingInt(CandidateDecisionKey::supportRank)
+                    .thenComparingInt(CandidateDecisionKey::distributorRank)
+                    .thenComparingInt(CandidateDecisionKey::volumeRank)
+                    .thenComparingInt(CandidateDecisionKey::yearRank);
+
+    @Override
+    public int compareTo(CandidateDecisionKey other) {
+        return COMPARATOR.compare(this, other);
+    }
+
+    public boolean hasStrongContradiction() {
+        return supportRank == 0 || volumeRank == 0 || yearRank == 0;
+    }
+}
+```
+
+Créer `src/main/java/fr/abes/bestppn/model/tiebreak/TieBreakDecision.java` :
+
+```java
+package fr.abes.bestppn.model.tiebreak;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public record TieBreakDecision(
+        String selectedPpn,
+        Map<String, CandidateDecisionKey> keys,
+        String reason) {
+
+    public TieBreakDecision {
+        keys = keys == null
+                ? Map.of()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(keys));
+    }
+
+    public static TieBreakDecision selected(
+            String ppn,
+            Map<String, CandidateDecisionKey> keys,
+            String decisiveCriterion) {
+        return new TieBreakDecision(ppn, keys, decisiveCriterion);
+    }
+
+    public static TieBreakDecision unresolved(
+            Map<String, CandidateDecisionKey> keys,
+            String reason) {
+        return new TieBreakDecision(null, keys, reason);
+    }
+
+    public boolean resolved() {
+        return selectedPpn != null;
+    }
+}
+```
+
+- [ ] **Step 8: Run all Task 1 tests**
+
+Run:
+
+```powershell
+mvn "-Dtest=TieBreakNormalizerTest,CandidateDecisionKeyTest" test
+```
+
+Expected: `Tests run: 10, Failures: 0, Errors: 0` puis `BUILD SUCCESS`.
+
+- [ ] **Step 9: Commit Task 1**
+
+Run:
+
+```powershell
+git add src/main/java/fr/abes/bestppn/model/tiebreak src/main/java/fr/abes/bestppn/utils/TieBreakNormalizer.java src/test/java/fr/abes/bestppn/model/tiebreak src/test/java/fr/abes/bestppn/utils/TieBreakNormalizerTest.java
+git -c user.name="Jerome Villiseck" -c user.email="jvk@abes.fr" commit -m "feat: ajouter les primitives de décision SOA-501"
+```
+
+Expected: un commit contenant uniquement les sept fichiers de la tâche.
+
+---
+
+### Task 2: Extraction des métadonnées UNIMARC
+
+**Files:**
+
+- Create: `src/main/java/fr/abes/bestppn/service/CandidateMetadataExtractor.java`
+- Test: `src/test/java/fr/abes/bestppn/service/CandidateMetadataExtractorTest.java`
+
+**Interfaces:**
+
+- Consumes: `CandidateMetadataExtractor.extract(String ppn, NoticeXml notice)`.
+- Produces: `CandidateMetadata` avec `AccessMode`, `214 #2$c`, `200$h`, `200$i`, date 1 de `100$a`, années de `214$d` et preuves `zone$sous-zone=valeur`.
+
+- [ ] **Step 1: Write the failing extractor tests**
+
+Créer `src/test/java/fr/abes/bestppn/service/CandidateMetadataExtractorTest.java` :
+
+```java
+package fr.abes.bestppn.service;
+
+import fr.abes.bestppn.model.entity.basexml.notice.Controlfield;
+import fr.abes.bestppn.model.entity.basexml.notice.Datafield;
+import fr.abes.bestppn.model.entity.basexml.notice.NoticeXml;
+import fr.abes.bestppn.model.entity.basexml.notice.SubField;
+import fr.abes.bestppn.model.tiebreak.AccessMode;
+import fr.abes.bestppn.model.tiebreak.CandidateMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CandidateMetadataExtractorTest {
+    private final CandidateMetadataExtractor extractor = new CandidateMetadataExtractor();
+
+    @Test
+    void extraitToutesLesMetadonneesUtiles() {
+        NoticeXml notice = notice(
+                field("530", " ", "b", "Ressource en ligne"),
+                field("214", "2", "c", "Cairn.info", "d", "[2021]"),
+                field("200", " ", "h", "Part II", "i", "Méthodes numériques"),
+                field("100", " ", "a", "20240723d2021    m  y0frey50      ba"));
+
+        CandidateMetadata metadata = extractor.extract("123456789", notice);
+
+        assertEquals(AccessMode.ONLINE, metadata.accessMode());
+        assertEquals(Set.of("cairn info"), metadata.distributors());
+        assertEquals(Set.of("2"), metadata.volumeNumbers());
+        assertEquals(Set.of("methodes numeriques"), metadata.partTitles());
+        assertEquals(Set.of(2021), metadata.yearsFrom100());
+        assertEquals(Set.of(2021), metadata.yearsFrom214());
+        assertTrue(metadata.evidence().contains("530$b=Ressource en ligne"));
+        assertFalse(metadata.unreadable());
+    }
+
+    @Test
+    void reconnaitUnSupportPhysiqueDansLesZonesDescriptives() {
+        NoticeXml notice = notice(
+                field("531", " ", "b", "CD-ROM"),
+                field("215", " ", "a", "1 disque optique numérique (DVD-ROM)"));
+
+        assertEquals(AccessMode.PHYSICAL, extractor.extract("123456789", notice).accessMode());
+    }
+
+    @Test
+    void conserveUnSupportHybrideCommeInconnu() {
+        NoticeXml notice = notice(
+                field("530", " ", "b", "Ressource en ligne"),
+                field("215", " ", "a", "1 CD-ROM"));
+
+        assertEquals(AccessMode.UNKNOWN, extractor.extract("123456789", notice).accessMode());
+    }
+
+    @Test
+    void neClassePasLaSeuleValeurODe008CommeAccesEnLigne() {
+        NoticeXml notice = notice();
+
+        assertEquals(AccessMode.UNKNOWN, extractor.extract("123456789", notice).accessMode());
+    }
+
+    @Test
+    void neConserveQueLes214QuiPortentLeSecondIndicateur2() {
+        NoticeXml notice = notice(
+                field("214", "0", "c", "Autre diffuseur"),
+                field("214", "2", "c", "Cairn.info"));
+
+        assertEquals(
+                Set.of("cairn info"),
+                extractor.extract("123456789", notice).distributors());
+    }
+
+    @Test
+    void extraitPlusieursAnnees214CommeDonneesContradictoires() {
+        NoticeXml notice = notice(
+                field("214", "0", "d", "DL 2020"),
+                field("214", "0", "d", "cop. 2021"));
+
+        CandidateMetadata metadata = extractor.extract("123456789", notice);
+
+        assertEquals(Set.of(2020, 2021), metadata.yearsFrom214());
+        assertTrue(metadata.hasContradictoryYears());
+    }
+
+    @Test
+    void marqueUneNoticeAbsenteOuSupprimeeCommeIllisible() {
+        assertTrue(extractor.extract("123456789", null).unreadable());
+
+        NoticeXml deleted = notice();
+        deleted.setLeader("     dam0 22        450 ");
+        assertTrue(extractor.extract("123456789", deleted).unreadable());
+    }
+
+    @Test
+    void tolereLesListesEtValeursNulles() {
+        NoticeXml notice = new NoticeXml();
+        notice.setLeader("     nam0 22        450 ");
+        notice.setControlfields(null);
+        notice.setDatafields(List.of(field("200", " ", "h", null)));
+
+        CandidateMetadata metadata = extractor.extract("123456789", notice);
+
+        assertFalse(metadata.unreadable());
+        assertTrue(metadata.volumeNumbers().isEmpty());
+    }
+
+    private static NoticeXml notice(Datafield... fields) {
+        NoticeXml notice = new NoticeXml();
+        notice.setLeader("     nam0 22        450 ");
+        Controlfield ppn = new Controlfield();
+        ppn.setTag("001");
+        ppn.setValue("123456789");
+        Controlfield type = new Controlfield();
+        type.setTag("008");
+        type.setValue("Oax3");
+        notice.setControlfields(List.of(ppn, type));
+        notice.setDatafields(List.of(fields));
+        return notice;
+    }
+
+    private static Datafield field(String tag, String ind2, String... codeValues) {
+        Datafield field = new Datafield();
+        field.setTag(tag);
+        field.setInd1(" ");
+        field.setInd2(ind2);
+        List<SubField> subFields = new ArrayList<>();
+        for (int index = 0; index < codeValues.length; index += 2) {
+            SubField subField = new SubField();
+            subField.setCode(codeValues[index]);
+            subField.setValue(codeValues[index + 1]);
+            subFields.add(subField);
+        }
+        field.setSubFields(subFields);
+        return field;
+    }
+}
+```
+
+- [ ] **Step 2: Run the extractor test to verify it fails**
+
+Run:
+
+```powershell
+mvn "-Dtest=CandidateMetadataExtractorTest" test
+```
+
+Expected: `FAIL` pendant `testCompile`, car `CandidateMetadataExtractor` n’existe pas.
+
+- [ ] **Step 3: Implement the XML extractor**
+
+Créer `src/main/java/fr/abes/bestppn/service/CandidateMetadataExtractor.java` :
+
+```java
+package fr.abes.bestppn.service;
+
+import fr.abes.bestppn.model.entity.basexml.notice.Controlfield;
+import fr.abes.bestppn.model.entity.basexml.notice.Datafield;
+import fr.abes.bestppn.model.entity.basexml.notice.NoticeXml;
+import fr.abes.bestppn.model.entity.basexml.notice.SubField;
+import fr.abes.bestppn.model.tiebreak.AccessMode;
+import fr.abes.bestppn.model.tiebreak.CandidateMetadata;
+import fr.abes.bestppn.utils.TieBreakNormalizer;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+@Component
+public class CandidateMetadataExtractor {
+    private static final List<String> ONLINE_MARKERS =
+            List.of("online", "en ligne", "ressource en ligne", "acces internet");
+    private static final List<String> PHYSICAL_MARKERS =
+            List.of("cd rom", "cederom", "dvd rom", "disque optique");
+
+    public CandidateMetadata extract(String ppn, NoticeXml notice) {
+        if (notice == null) {
+            return CandidateMetadata.unreadable(ppn, "notice absente");
+        }
+        if (notice.getLeader() != null
+                && notice.getLeader().length() > 5
+                && notice.getLeader().charAt(5) == 'd') {
+            return CandidateMetadata.unreadable(ppn, "notice supprimée");
+        }
+
+        Set<String> supportValues = new LinkedHashSet<>();
+        Set<String> distributors = new LinkedHashSet<>();
+        Set<String> volumeNumbers = new LinkedHashSet<>();
+        Set<String> partTitles = new LinkedHashSet<>();
+        Set<Integer> yearsFrom100 = new LinkedHashSet<>();
+        Set<Integer> yearsFrom214 = new LinkedHashSet<>();
+        List<String> evidence = new ArrayList<>();
+
+        for (Controlfield controlfield : safeControlfields(notice)) {
+            if (controlfield != null && Objects.equals("008", controlfield.getTag())) {
+                addEvidence(evidence, "008", null, controlfield.getValue());
+            }
+        }
+
+        for (Datafield field : safeDatafields(notice)) {
+            if (field == null || field.getTag() == null) {
+                continue;
+            }
+            switch (field.getTag()) {
+                case "530", "531" -> values(field, "b").forEach(value -> {
+                    addNormalized(supportValues, value);
+                    addEvidence(evidence, field.getTag(), "b", value);
+                });
+                case "215" -> safeSubfields(field).forEach(subfield -> {
+                    addNormalized(supportValues, subfield.getValue());
+                    addEvidence(evidence, "215", subfield.getCode(), subfield.getValue());
+                });
+                case "214" -> extractPublicationField(
+                        field, distributors, yearsFrom214, evidence);
+                case "200" -> extractTitleField(
+                        field, volumeNumbers, partTitles, evidence);
+                case "100" -> values(field, "a").forEach(value -> {
+                    TieBreakNormalizer.extractDate1From100(value).ifPresent(yearsFrom100::add);
+                    addEvidence(evidence, "100", "a", value);
+                });
+                default -> {
+                }
+            }
+        }
+
+        return new CandidateMetadata(
+                ppn,
+                accessMode(supportValues),
+                distributors,
+                volumeNumbers,
+                partTitles,
+                yearsFrom100,
+                yearsFrom214,
+                evidence,
+                false);
+    }
+
+    private void extractPublicationField(
+            Datafield field,
+            Set<String> distributors,
+            Set<Integer> years,
+            List<String> evidence) {
+        values(field, "d").forEach(value -> {
+            years.addAll(TieBreakNormalizer.extractYears(value));
+            addEvidence(evidence, "214", "d", value);
+        });
+        if (Objects.equals("2", field.getInd2())) {
+            values(field, "c").forEach(value -> {
+                addNormalized(distributors, value);
+                addEvidence(evidence, "214", "c", value);
+            });
+        }
+    }
+
+    private void extractTitleField(
+            Datafield field,
+            Set<String> volumeNumbers,
+            Set<String> partTitles,
+            List<String> evidence) {
+        values(field, "h").forEach(value -> {
+            TieBreakNormalizer.normalizeVolume(value).ifPresent(volumeNumbers::add);
+            addEvidence(evidence, "200", "h", value);
+        });
+        values(field, "i").forEach(value -> {
+            addNormalized(partTitles, value);
+            addEvidence(evidence, "200", "i", value);
+        });
+    }
+
+    private AccessMode accessMode(Set<String> supportValues) {
+        boolean online = containsMarker(supportValues, ONLINE_MARKERS);
+        boolean physical = containsMarker(supportValues, PHYSICAL_MARKERS);
+        if (online == physical) {
+            return AccessMode.UNKNOWN;
+        }
+        return online ? AccessMode.ONLINE : AccessMode.PHYSICAL;
+    }
+
+    private boolean containsMarker(Set<String> values, List<String> markers) {
+        return values.stream().anyMatch(value ->
+                markers.stream().anyMatch(value::contains));
+    }
+
+    private List<String> values(Datafield field, String code) {
+        return safeSubfields(field).stream()
+                .filter(subfield -> Objects.equals(code, subfield.getCode()))
+                .map(SubField::getValue)
+                .filter(Objects::nonNull)
+                .filter(value -> !value.isBlank())
+                .toList();
+    }
+
+    private List<Datafield> safeDatafields(NoticeXml notice) {
+        return notice.getDatafields() == null ? List.of() : notice.getDatafields();
+    }
+
+    private List<Controlfield> safeControlfields(NoticeXml notice) {
+        return notice.getControlfields() == null ? List.of() : notice.getControlfields();
+    }
+
+    private List<SubField> safeSubfields(Datafield field) {
+        return field.getSubFields() == null ? List.of() : field.getSubFields();
+    }
+
+    private void addNormalized(Set<String> target, String value) {
+        String normalized = TieBreakNormalizer.normalizeText(value);
+        if (!normalized.isBlank()) {
+            target.add(normalized);
+        }
+    }
+
+    private void addEvidence(List<String> evidence, String tag, String code, String value) {
+        if (value != null && !value.isBlank()) {
+            evidence.add(tag + (code == null ? "" : "$" + code) + "=" + value);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the extractor tests**
+
+Run:
+
+```powershell
+mvn "-Dtest=CandidateMetadataExtractorTest" test
+```
+
+Expected: `Tests run: 8, Failures: 0, Errors: 0` puis `BUILD SUCCESS`.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```powershell
+git add src/main/java/fr/abes/bestppn/service/CandidateMetadataExtractor.java src/test/java/fr/abes/bestppn/service/CandidateMetadataExtractorTest.java
+git -c user.name="Jerome Villiseck" -c user.email="jvk@abes.fr" commit -m "feat: extraire les métadonnées de départage des notices"
+```
+
+Expected: un commit contenant l’extracteur et ses tests uniquement.
+
+---
+
+### Task 3: Moteur d’arbitrage SOA-501
+
+**Files:**
+
+- Create: `src/main/java/fr/abes/bestppn/service/BestPpnTieBreakerService.java`
+- Test: `src/test/java/fr/abes/bestppn/service/BestPpnTieBreakerServiceTest.java`
+
+**Interfaces:**
+
+- Consumes: `resolve(LigneKbartDto kbart, String providerCode, Map<String, Integer> tiedCandidates)`.
+- Consumes: `NoticeService.getNoticeByPpn(String)` et `ProviderService.findByProvider(String)`.
+- Produces: une `TieBreakDecision` résolue uniquement si une clé est strictement maximale et sans contradiction forte.
+
+- [ ] **Step 1: Write the failing arbitration tests**
+
+Créer `src/test/java/fr/abes/bestppn/service/BestPpnTieBreakerServiceTest.java` :
+
+```java
+package fr.abes.bestppn.service;
+
+import fr.abes.bestppn.model.dto.kafka.LigneKbartDto;
+import fr.abes.bestppn.model.entity.bacon.Provider;
+import fr.abes.bestppn.model.entity.basexml.notice.NoticeXml;
+import fr.abes.bestppn.model.tiebreak.AccessMode;
+import fr.abes.bestppn.model.tiebreak.CandidateMetadata;
+import fr.abes.bestppn.model.tiebreak.TieBreakDecision;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BestPpnTieBreakerServiceTest {
+    @Mock
+    private NoticeService noticeService;
+    @Mock
+    private ProviderService providerService;
+    @Mock
+    private CandidateMetadataExtractor extractor;
+
+    private BestPpnTieBreakerService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new BestPpnTieBreakerService(noticeService, providerService, extractor);
+    }
+
+    @Test
+    void supportEstPrioritairePourUneSerie() throws IOException {
+        LigneKbartDto kbart = kbart("serial");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE));
+        candidate("100000002", metadata("100000002", AccessMode.UNKNOWN));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertTrue(decision.resolved());
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals("SUPPORT", decision.reason());
+    }
+
+    @Test
+    void diffuseurDepartageDeuxMonographies() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        Provider provider = provider("CAIRN", "Cairn.info");
+        when(providerService.findByProvider("CAIRN")).thenReturn(Optional.of(provider));
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of("cairn info"), Set.of(), Set.of(), Set.of(), Set.of()));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of("autre diffuseur"), Set.of(), Set.of(), Set.of(), Set.of()));
+
+        TieBreakDecision decision = service.resolve(kbart, "CAIRN", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals(2, decision.keys().get("100000001").distributorRank());
+        assertEquals(0, decision.keys().get("100000002").distributorRank());
+    }
+
+    @Test
+    void volumeExactDepartageDeuxMonographies() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setMonographVolume("Tome II");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of(), Set.of("2"), Set.of(), Set.of(), Set.of()));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of(), Set.of("3"), Set.of(), Set.of(), Set.of()));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals(3, decision.keys().get("100000001").volumeRank());
+        assertEquals(0, decision.keys().get("100000002").volumeRank());
+    }
+
+    @Test
+    void titreDePartieDepartageSansMonographVolume() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setPublicationTitle("Traité complet - Méthodes numériques");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of(), Set.of(), Set.of("methodes numeriques"), Set.of(), Set.of()));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of(), Set.of(), Set.of("autre partie"), Set.of(), Set.of()));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals(2, decision.keys().get("100000001").volumeRank());
+        assertEquals(1, decision.keys().get("100000002").volumeRank());
+    }
+
+    @Test
+    void anneeEnLigneEstPrioritaireSurAnneeImprimee() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setDateMonographPublishedOnline("2021-01-01");
+        kbart.setDateMonographPublishedPrint("2020");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of(), Set.of(), Set.of(), Set.of(2021), Set.of(2021)));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of(), Set.of(), Set.of(), Set.of(2020), Set.of(2020)));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals(3, decision.keys().get("100000001").yearRank());
+        assertEquals(2, decision.keys().get("100000002").yearRank());
+    }
+
+    @Test
+    void egaliteDeClesResteIndecidable() throws IOException {
+        LigneKbartDto kbart = kbart("serial");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertFalse(decision.resolved());
+        assertEquals("clés identiques", decision.reason());
+    }
+
+    @Test
+    void lectureXmlImpossibleConserveLegalite() throws IOException {
+        LigneKbartDto kbart = kbart("serial");
+        when(noticeService.getNoticeByPpn("100000001")).thenThrow(new IOException("base indisponible"));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertFalse(decision.resolved());
+        assertEquals("notice absente, supprimée ou illisible", decision.reason());
+        verify(noticeService, times(1)).getNoticeByPpn("100000001");
+        verify(noticeService, times(1)).getNoticeByPpn("100000002");
+    }
+
+    @Test
+    void supportPhysiqueInterditLaSelection() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        Provider provider = provider("CAIRN", "Cairn.info");
+        when(providerService.findByProvider("CAIRN")).thenReturn(Optional.of(provider));
+        candidate("100000001", metadata("100000001", AccessMode.PHYSICAL, Set.of("cairn info"), Set.of(), Set.of(), Set.of(), Set.of()));
+        candidate("100000002", metadata("100000002", AccessMode.PHYSICAL, Set.of("autre diffuseur"), Set.of(), Set.of(), Set.of(), Set.of()));
+
+        TieBreakDecision decision = service.resolve(kbart, "CAIRN", ties());
+
+        assertFalse(decision.resolved());
+        assertEquals("contradiction forte sur le meilleur candidat", decision.reason());
+    }
+
+    @Test
+    void volumeExplicitementIncompatibleInterditLaSelection() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setMonographVolume("2");
+        kbart.setDateMonographPublishedOnline("2021");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of(), Set.of("3"), Set.of(), Set.of(2021), Set.of(2021)));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of(), Set.of("4"), Set.of(), Set.of(2020), Set.of(2020)));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertFalse(decision.resolved());
+        assertEquals(0, decision.keys().get("100000001").volumeRank());
+    }
+
+    @Test
+    void anneeExplicitementIncompatibleInterditLaSelection() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setDateMonographPublishedOnline("2021");
+        Provider provider = provider("CAIRN", "Cairn.info");
+        when(providerService.findByProvider("CAIRN")).thenReturn(Optional.of(provider));
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of("cairn info"), Set.of(), Set.of(), Set.of(2019), Set.of(2019)));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of("autre diffuseur"), Set.of(), Set.of(), Set.of(2018), Set.of(2018)));
+
+        TieBreakDecision decision = service.resolve(kbart, "CAIRN", ties());
+
+        assertFalse(decision.resolved());
+        assertEquals(0, decision.keys().get("100000001").yearRank());
+    }
+
+    @Test
+    void seriesIgnorentDiffuseurVolumeEtAnnee() throws IOException {
+        LigneKbartDto kbart = kbart("serial");
+        kbart.setMonographVolume("2");
+        kbart.setDateMonographPublishedOnline("2021");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of("cairn info"), Set.of("2"), Set.of(), Set.of(2021), Set.of()));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of("autre"), Set.of("3"), Set.of(), Set.of(2020), Set.of()));
+
+        TieBreakDecision decision = service.resolve(kbart, "CAIRN", ties());
+
+        assertFalse(decision.resolved());
+        assertEquals(1, decision.keys().get("100000001").distributorRank());
+        assertEquals(1, decision.keys().get("100000001").volumeRank());
+        assertEquals(1, decision.keys().get("100000001").yearRank());
+    }
+
+    private void candidate(String ppn, CandidateMetadata metadata) throws IOException {
+        NoticeXml notice = new NoticeXml();
+        when(noticeService.getNoticeByPpn(ppn)).thenReturn(notice);
+        when(extractor.extract(ppn, notice)).thenReturn(metadata);
+    }
+
+    private static LigneKbartDto kbart(String publicationType) {
+        LigneKbartDto kbart = new LigneKbartDto();
+        kbart.setPublicationType(publicationType);
+        kbart.setPublicationTitle("Titre");
+        return kbart;
+    }
+
+    private static Map<String, Integer> ties() {
+        Map<String, Integer> candidates = new LinkedHashMap<>();
+        candidates.put("100000001", 10);
+        candidates.put("100000002", 10);
+        return candidates;
+    }
+
+    private static CandidateMetadata metadata(String ppn, AccessMode accessMode) {
+        return metadata(ppn, accessMode, Set.of(), Set.of(), Set.of(), Set.of(), Set.of());
+    }
+
+    private static CandidateMetadata metadata(
+            String ppn,
+            AccessMode accessMode,
+            Set<String> distributors,
+            Set<String> volumeNumbers,
+            Set<String> partTitles,
+            Set<Integer> yearsFrom100,
+            Set<Integer> yearsFrom214) {
+        return new CandidateMetadata(
+                ppn,
+                accessMode,
+                distributors,
+                volumeNumbers,
+                partTitles,
+                yearsFrom100,
+                yearsFrom214,
+                List.of(),
+                false);
+    }
+
+    private static Provider provider(String code, String displayName) {
+        Provider provider = new Provider(code);
+        provider.setDisplayName(displayName);
+        return provider;
+    }
+}
+```
+
+- [ ] **Step 2: Run the arbitration test to verify it fails**
+
+Run:
+
+```powershell
+mvn "-Dtest=BestPpnTieBreakerServiceTest" test
+```
+
+Expected: `FAIL` pendant `testCompile`, car `BestPpnTieBreakerService` n’existe pas.
+
+- [ ] **Step 3: Implement the arbitration service**
+
+Créer `src/main/java/fr/abes/bestppn/service/BestPpnTieBreakerService.java` :
+
+```java
+package fr.abes.bestppn.service;
+
+import fr.abes.bestppn.model.dto.kafka.LigneKbartDto;
+import fr.abes.bestppn.model.entity.bacon.Provider;
+import fr.abes.bestppn.model.entity.basexml.notice.NoticeXml;
+import fr.abes.bestppn.model.tiebreak.AccessMode;
+import fr.abes.bestppn.model.tiebreak.CandidateDecisionKey;
+import fr.abes.bestppn.model.tiebreak.CandidateMetadata;
+import fr.abes.bestppn.model.tiebreak.TieBreakDecision;
+import fr.abes.bestppn.utils.PUBLICATION_TYPE;
+import fr.abes.bestppn.utils.TieBreakNormalizer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.function.ToIntFunction;
+
+import static fr.abes.bestppn.utils.LogMarkers.FUNCTIONAL;
+import static fr.abes.bestppn.utils.LogMarkers.TECHNICAL;
+
+@Service
+@Slf4j
+public class BestPpnTieBreakerService {
+    private final NoticeService noticeService;
+    private final ProviderService providerService;
+    private final CandidateMetadataExtractor extractor;
+
+    public BestPpnTieBreakerService(
+            NoticeService noticeService,
+            ProviderService providerService,
+            CandidateMetadataExtractor extractor) {
+        this.noticeService = noticeService;
+        this.providerService = providerService;
+        this.extractor = extractor;
+    }
+
+    public TieBreakDecision resolve(
+            LigneKbartDto kbart,
+            String providerCode,
+            Map<String, Integer> tiedCandidates) {
+        if (tiedCandidates == null || tiedCandidates.size() < 2) {
+            return TieBreakDecision.unresolved(Map.of(), "moins de deux candidats");
+        }
+
+        log.info(FUNCTIONAL,
+                "Arbitrage SOA-501 : candidats={}, scores={}",
+                tiedCandidates.keySet(),
+                tiedCandidates);
+
+        Optional<Provider> provider = findProvider(providerCode);
+        Map<String, CandidateMetadata> metadataByPpn = loadMetadata(tiedCandidates.keySet());
+        log.info(FUNCTIONAL,
+                "Arbitrage SOA-501 : KBART provider={}, titre={}, volume={}, annéeEnLigne={}, annéeImprimée={}",
+                TieBreakNormalizer.normalizeText(providerCode),
+                TieBreakNormalizer.normalizeText(kbart.getPublicationTitle()),
+                TieBreakNormalizer.normalizeVolume(kbart.getMonographVolume()).orElse(""),
+                TieBreakNormalizer.extractYear(kbart.getDateMonographPublishedOnline())
+                        .stream().boxed().findFirst().orElse(null),
+                TieBreakNormalizer.extractYear(kbart.getDateMonographPublishedPrint())
+                        .stream().boxed().findFirst().orElse(null));
+        Map<String, CandidateDecisionKey> keys = buildKeys(
+                kbart, provider.orElse(null), tiedCandidates, metadataByPpn);
+
+        keys.forEach((ppn, key) -> log.info(
+                FUNCTIONAL,
+                "Arbitrage SOA-501 : ppn={}, clé={}, preuves={}",
+                ppn,
+                key,
+                metadataByPpn.get(ppn).evidence()));
+
+        if (metadataByPpn.values().stream().anyMatch(CandidateMetadata::unreadable)) {
+            log.warn(FUNCTIONAL,
+                    "Arbitrage SOA-501 indécidable : notice absente, supprimée ou illisible");
+            return TieBreakDecision.unresolved(
+                    keys, "notice absente, supprimée ou illisible");
+        }
+
+        CandidateDecisionKey maxKey = keys.values().stream()
+                .max(Comparator.naturalOrder())
+                .orElseThrow();
+        List<String> winners = keys.entrySet().stream()
+                .filter(entry -> entry.getValue().equals(maxKey))
+                .map(Map.Entry::getKey)
+                .toList();
+
+        if (winners.size() != 1) {
+            log.warn(FUNCTIONAL,
+                    "Arbitrage SOA-501 indécidable : clés identiques pour {}",
+                    winners);
+            return TieBreakDecision.unresolved(keys, "clés identiques");
+        }
+
+        String winner = winners.getFirst();
+        String decisiveCriterion = logCascadeAndFindDecisiveCriterion(keys);
+        if (maxKey.hasStrongContradiction()) {
+            log.warn(FUNCTIONAL,
+                    "Arbitrage SOA-501 refusé : ppn={}, clé={}, contradiction forte",
+                    winner,
+                    maxKey);
+            return TieBreakDecision.unresolved(
+                    keys, "contradiction forte sur le meilleur candidat");
+        }
+
+        log.info(FUNCTIONAL,
+                "Arbitrage SOA-501 résolu : ppn={}, critère décisif={}",
+                winner,
+                decisiveCriterion);
+        return TieBreakDecision.selected(winner, keys, decisiveCriterion);
+    }
+
+    private Optional<Provider> findProvider(String providerCode) {
+        if (providerCode == null || providerCode.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            return providerService.findByProvider(providerCode);
+        } catch (RuntimeException exception) {
+            log.error(TECHNICAL,
+                    "Impossible de charger le provider {} pendant l'arbitrage SOA-501",
+                    providerCode,
+                    exception);
+            return Optional.empty();
+        }
+    }
+
+    private Map<String, CandidateMetadata> loadMetadata(Set<String> ppns) {
+        Map<String, CandidateMetadata> result = new LinkedHashMap<>();
+        ppns.stream().sorted().forEach(ppn -> {
+            try {
+                NoticeXml notice = noticeService.getNoticeByPpn(ppn);
+                result.put(ppn, extractor.extract(ppn, notice));
+            } catch (IOException | RuntimeException exception) {
+                log.error(TECHNICAL,
+                        "Impossible de charger la notice {} pendant l'arbitrage SOA-501",
+                        ppn,
+                        exception);
+                result.put(ppn, CandidateMetadata.unreadable(
+                        ppn, "erreur de lecture XML"));
+            }
+        });
+        return result;
+    }
+
+    private Map<String, CandidateDecisionKey> buildKeys(
+            LigneKbartDto kbart,
+            Provider provider,
+            Map<String, Integer> tiedCandidates,
+            Map<String, CandidateMetadata> metadataByPpn) {
+        Map<String, CandidateDecisionKey> keys = new LinkedHashMap<>();
+        tiedCandidates.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> {
+                    CandidateMetadata metadata = metadataByPpn.get(entry.getKey());
+                    keys.put(entry.getKey(), new CandidateDecisionKey(
+                            entry.getValue(),
+                            supportRank(metadata),
+                            distributorRank(kbart, provider, metadata),
+                            volumeRank(kbart, metadata),
+                            yearRank(kbart, metadata)));
+                });
+        return keys;
+    }
+
+    private int supportRank(CandidateMetadata metadata) {
+        return switch (metadata.accessMode()) {
+            case ONLINE -> 2;
+            case UNKNOWN -> 1;
+            case PHYSICAL -> 0;
+        };
+    }
+
+    private int distributorRank(
+            LigneKbartDto kbart,
+            Provider provider,
+            CandidateMetadata metadata) {
+        if (!isMonograph(kbart)) {
+            return 1;
+        }
+        if (provider == null || metadata.distributors().isEmpty()) {
+            return 1;
+        }
+
+        String displayName = TieBreakNormalizer.normalizeText(provider.getDisplayName());
+        boolean match = metadata.distributors().stream().anyMatch(distributor ->
+                TieBreakNormalizer.containsWord(distributor, provider.getProvider())
+                        || (!displayName.isBlank()
+                        && (distributor.equals(displayName)
+                        || distributor.contains(displayName))));
+        return match ? 2 : 0;
+    }
+
+    private int volumeRank(LigneKbartDto kbart, CandidateMetadata metadata) {
+        if (!isMonograph(kbart)) {
+            return 1;
+        }
+
+        Optional<String> expectedVolume =
+                TieBreakNormalizer.normalizeVolume(kbart.getMonographVolume());
+        if (expectedVolume.isEmpty()) {
+            expectedVolume = TieBreakNormalizer.extractVolumeFromTitle(
+                    kbart.getPublicationTitle());
+        }
+
+        if (expectedVolume.isPresent()
+                && metadata.volumeNumbers().contains(expectedVolume.get())) {
+            return 3;
+        }
+
+        String normalizedTitle =
+                TieBreakNormalizer.normalizeText(kbart.getPublicationTitle());
+        boolean partTitleMatch = metadata.partTitles().stream()
+                .anyMatch(partTitle -> !partTitle.isBlank()
+                        && normalizedTitle.contains(partTitle));
+        if (partTitleMatch) {
+            return 2;
+        }
+
+        return expectedVolume.isEmpty() ? 1 : 0;
+    }
+
+    private int yearRank(LigneKbartDto kbart, CandidateMetadata metadata) {
+        if (!isMonograph(kbart)) {
+            return 1;
+        }
+
+        OptionalInt onlineYear = TieBreakNormalizer.extractYear(
+                kbart.getDateMonographPublishedOnline());
+        OptionalInt printYear = TieBreakNormalizer.extractYear(
+                kbart.getDateMonographPublishedPrint());
+        if (onlineYear.isEmpty() && printYear.isEmpty()) {
+            return 1;
+        }
+
+        Set<Integer> sudocYears = metadata.allYears();
+        if (sudocYears.isEmpty() || metadata.hasContradictoryYears()) {
+            return 1;
+        }
+        if (onlineYear.isPresent() && sudocYears.contains(onlineYear.getAsInt())) {
+            return 3;
+        }
+        if (printYear.isPresent() && sudocYears.contains(printYear.getAsInt())) {
+            return 2;
+        }
+        return 0;
+    }
+
+    private boolean isMonograph(LigneKbartDto kbart) {
+        return kbart != null
+                && PUBLICATION_TYPE.MONOGRAPH.name().equalsIgnoreCase(
+                kbart.getPublicationType());
+    }
+
+    private String logCascadeAndFindDecisiveCriterion(
+            Map<String, CandidateDecisionKey> keys) {
+        List<String> survivors = new ArrayList<>(keys.keySet());
+        String decisive = "AUCUN";
+        decisive = decisiveAfterStep(
+                survivors, keys, CandidateDecisionKey::currentScore, "SCORE");
+        if (!decisive.equals("AUCUN")) {
+            return decisive;
+        }
+        decisive = decisiveAfterStep(
+                survivors, keys, CandidateDecisionKey::supportRank, "SUPPORT");
+        if (!decisive.equals("AUCUN")) {
+            return decisive;
+        }
+        decisive = decisiveAfterStep(
+                survivors, keys, CandidateDecisionKey::distributorRank, "DIFFUSEUR");
+        if (!decisive.equals("AUCUN")) {
+            return decisive;
+        }
+        decisive = decisiveAfterStep(
+                survivors, keys, CandidateDecisionKey::volumeRank, "VOLUME");
+        if (!decisive.equals("AUCUN")) {
+            return decisive;
+        }
+        return decisiveAfterStep(
+                survivors, keys, CandidateDecisionKey::yearRank, "ANNÉE");
+    }
+
+    private String decisiveAfterStep(
+            List<String> survivors,
+            Map<String, CandidateDecisionKey> keys,
+            ToIntFunction<CandidateDecisionKey> rank,
+            String criterion) {
+        int max = survivors.stream()
+                .map(keys::get)
+                .mapToInt(rank)
+                .max()
+                .orElseThrow();
+        List<String> eliminated = survivors.stream()
+                .filter(ppn -> rank.applyAsInt(keys.get(ppn)) < max)
+                .toList();
+        survivors.removeAll(eliminated);
+        if (!eliminated.isEmpty()) {
+            log.info(FUNCTIONAL,
+                    "Arbitrage SOA-501 : critère={}, éliminés={}, restants={}",
+                    criterion,
+                    eliminated,
+                    survivors);
+        }
+        return survivors.size() == 1 ? criterion : "AUCUN";
+    }
+}
+```
+
+- [ ] **Step 4: Run the arbitration tests**
+
+Run:
+
+```powershell
+mvn "-Dtest=BestPpnTieBreakerServiceTest" test
+```
+
+Expected: `Tests run: 11, Failures: 0, Errors: 0` puis `BUILD SUCCESS`.
+
+- [ ] **Step 5: Commit Task 3**
+
+Run:
+
+```powershell
+git add src/main/java/fr/abes/bestppn/service/BestPpnTieBreakerService.java src/test/java/fr/abes/bestppn/service/BestPpnTieBreakerServiceTest.java
+git -c user.name="Jerome Villiseck" -c user.email="jvk@abes.fr" commit -m "feat: arbitrer les PPN ex aequo selon SOA-501"
+```
+
+Expected: un commit contenant le moteur d’arbitrage et ses tests uniquement.
+
+---
+
+### Task 4: Intégration dans BestPpnService
+
+**Files:**
+
+- Modify: `src/main/java/fr/abes/bestppn/service/BestPpnService.java:40-54`
+- Modify: `src/main/java/fr/abes/bestppn/service/BestPpnService.java:81`
+- Modify: `src/main/java/fr/abes/bestppn/service/BestPpnService.java:199-247`
+- Modify: `src/test/java/fr/abes/bestppn/service/BestPpnServiceTest.java:35-51`
+- Modify: `src/test/java/fr/abes/bestppn/service/BestPpnServiceTest.java:358-401`
+- Create: `src/test/java/fr/abes/bestppn/service/BestPpnServiceTieBreakTest.java`
+
+**Interfaces:**
+
+- Consumes: `BestPpnTieBreakerService.resolve(kbart, provider, ppnElecScore)`.
+- Changes: `getBestPpnByScore` reçoit désormais le provider en deuxième paramètre.
+- Preserves: texte d’erreur actuel, mode forcé, traitement des PPN imprimés et sélection directe d’un maximum unique.
+
+- [ ] **Step 1: Write the failing BestPpnService integration tests**
+
+Créer `src/test/java/fr/abes/bestppn/service/BestPpnServiceTieBreakTest.java` :
+
+```java
+package fr.abes.bestppn.service;
+
+import fr.abes.bestppn.exception.BestPpnException;
+import fr.abes.bestppn.kafka.TopicProducer;
+import fr.abes.bestppn.model.BestPpn;
+import fr.abes.bestppn.model.dto.kafka.LigneKbartDto;
+import fr.abes.bestppn.model.tiebreak.CandidateDecisionKey;
+import fr.abes.bestppn.model.tiebreak.TieBreakDecision;
+import fr.abes.bestppn.utils.DESTINATION_TOPIC;
+import fr.abes.bestppn.utils.TYPE_SUPPORT;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BestPpnServiceTieBreakTest {
+    @Mock
+    private WsService wsService;
+    @Mock
+    private TopicProducer topicProducer;
+    @Mock
+    private CheckUrlService checkUrlService;
+    @Mock
+    private BestPpnTieBreakerService tieBreakerService;
+
+    private BestPpnService service;
+    private LigneKbartDto kbart;
+
+    @BeforeEach
+    void setUp() {
+        service = new BestPpnService(
+                wsService, topicProducer, checkUrlService, tieBreakerService);
+        kbart = new LigneKbartDto();
+        kbart.setPublicationTitle("Titre");
+        kbart.setPublicationType("monograph");
+    }
+
+    @Test
+    void utiliseLePpnRetenuPourUneEgaliteMaximale() throws BestPpnException {
+        Map<String, Integer> candidates = ties();
+        CandidateDecisionKey selectedKey =
+                new CandidateDecisionKey(10, 2, 1, 1, 1);
+        when(tieBreakerService.resolve(kbart, "CAIRN", candidates))
+                .thenReturn(TieBreakDecision.selected(
+                        "100000001",
+                        Map.of("100000001", selectedKey),
+                        "SUPPORT"));
+
+        BestPpn result = service.getBestPpnByScore(
+                kbart, "CAIRN", candidates, Set.of(), false);
+
+        assertEquals("100000001", result.getPpn());
+        assertEquals(DESTINATION_TOPIC.BEST_PPN_BACON, result.getDestination());
+        assertEquals(TYPE_SUPPORT.ELECTRONIQUE, result.getTypeSupport());
+    }
+
+    @Test
+    void conserveLexcpetionActuelleSiLarbitrageEchoue() {
+        Map<String, Integer> candidates = ties();
+        when(tieBreakerService.resolve(kbart, "CAIRN", candidates))
+                .thenReturn(TieBreakDecision.unresolved(
+                        Map.of(), "clés identiques"));
+
+        BestPpnException exception = assertThrows(
+                BestPpnException.class,
+                () -> service.getBestPpnByScore(
+                        kbart, "CAIRN", candidates, Set.of(), false));
+
+        assertTrue(exception.getMessage().startsWith(
+                "Plusieurs ppn électroniques ("));
+        assertTrue(exception.getMessage().contains(
+                ") ont le même score."));
+    }
+
+    @Test
+    void conserveLeBestPpnVideEnModeForceSiLarbitrageEchoue()
+            throws BestPpnException {
+        Map<String, Integer> candidates = ties();
+        when(tieBreakerService.resolve(kbart, "CAIRN", candidates))
+                .thenReturn(TieBreakDecision.unresolved(
+                        Map.of(), "clés identiques"));
+
+        BestPpn result = service.getBestPpnByScore(
+                kbart, "CAIRN", candidates, Set.of(), true);
+
+        assertEquals("", result.getPpn());
+        assertEquals(DESTINATION_TOPIC.BEST_PPN_BACON, result.getDestination());
+    }
+
+    @Test
+    void nappellePasLarbitragePourUnMaximumUnique()
+            throws BestPpnException {
+        Map<String, Integer> candidates = new LinkedHashMap<>();
+        candidates.put("100000001", 10);
+        candidates.put("100000002", 5);
+
+        BestPpn result = service.getBestPpnByScore(
+                kbart, "CAIRN", candidates, Set.of(), false);
+
+        assertEquals("100000001", result.getPpn());
+        verifyNoInteractions(tieBreakerService);
+    }
+
+    private static Map<String, Integer> ties() {
+        Map<String, Integer> candidates = new LinkedHashMap<>();
+        candidates.put("100000001", 10);
+        candidates.put("100000002", 10);
+        return candidates;
+    }
+}
+```
+
+- [ ] **Step 2: Run the integration test to verify it fails**
+
+Run:
+
+```powershell
+mvn "-Dtest=BestPpnServiceTieBreakTest" test
+```
+
+Expected: `FAIL` pendant `testCompile`, car le constructeur et `getBestPpnByScore` n’ont pas encore leur nouvelle signature.
+
+- [ ] **Step 3: Wire the tie-breaker into BestPpnService**
+
+Dans `src/main/java/fr/abes/bestppn/service/BestPpnService.java`, ajouter l’import :
+
+```java
+import fr.abes.bestppn.model.tiebreak.TieBreakDecision;
+```
+
+Remplacer le champ `NoticeService` et le constructeur par :
+
+```java
+    private final BestPpnTieBreakerService tieBreakerService;
+
+    private final TopicProducer topicProducer;
+
+    private final CheckUrlService checkUrlService;
+
+    public BestPpnService(
+            WsService service,
+            TopicProducer topicProducer,
+            CheckUrlService checkUrlService,
+            BestPpnTieBreakerService tieBreakerService) {
+        this.service = service;
+        this.topicProducer = topicProducer;
+        this.checkUrlService = checkUrlService;
+        this.tieBreakerService = tieBreakerService;
+    }
+```
+
+Remplacer l’appel final de `getBestPpn` par :
+
+```java
+        return getBestPpnByScore(
+                kbart,
+                provider,
+                ppnElecScoredList,
+                ppnPrintResultList,
+                isForced);
+```
+
+Remplacer entièrement `getBestPpnByScore` par :
+
+```java
+    public BestPpn getBestPpnByScore(
+            LigneKbartDto kbart,
+            String provider,
+            Map<String, Integer> ppnElecResultList,
+            Set<String> ppnPrintResultList,
+            boolean isForced) throws BestPpnException {
+        Map<String, Integer> ppnElecScore =
+                Utils.getMaxValuesFromMap(ppnElecResultList);
+        return switch (ppnElecScore.size()) {
+            case 0 -> {
+                log.info(FUNCTIONAL, "Aucun ppn électronique trouvé. " + kbart);
+                yield switch (ppnPrintResultList.size()) {
+                    case 0 -> {
+                        kbart.setErrorType("Aucun ppn trouvé");
+                        yield new BestPpn(
+                                null, DESTINATION_TOPIC.NO_PPN_FOUND_SUDOC);
+                    }
+                    case 1 -> {
+                        String printPpn =
+                                ppnPrintResultList.stream().toList().getFirst();
+                        kbart.setErrorType(
+                                "Ppn imprimé trouvé : " + printPpn);
+                        log.debug(TECHNICAL, kbart.getErrorType());
+                        yield new BestPpn(
+                                printPpn,
+                                DESTINATION_TOPIC.PRINT_PPN_SUDOC,
+                                TYPE_SUPPORT.IMPRIME);
+                    }
+                    default -> unresolvedPrintTie(
+                            kbart, ppnPrintResultList, isForced);
+                };
+            }
+            case 1 -> new BestPpn(
+                    ppnElecScore.keySet().stream().findFirst().orElseThrow(),
+                    DESTINATION_TOPIC.BEST_PPN_BACON,
+                    TYPE_SUPPORT.ELECTRONIQUE);
+            default -> {
+                TieBreakDecision decision =
+                        tieBreakerService.resolve(kbart, provider, ppnElecScore);
+                if (decision.resolved()) {
+                    yield new BestPpn(
+                            decision.selectedPpn(),
+                            DESTINATION_TOPIC.BEST_PPN_BACON,
+                            TYPE_SUPPORT.ELECTRONIQUE);
+                }
+                yield unresolvedElectronicTie(
+                        kbart, ppnElecScore, isForced);
+            }
+        };
+    }
+
+    private BestPpn unresolvedPrintTie(
+            LigneKbartDto kbart,
+            Set<String> ppnPrintResultList,
+            boolean isForced) throws BestPpnException {
+        String errorString = "Plusieurs ppn imprimés ("
+                + String.join(" OU ", ppnPrintResultList)
+                + ") ont été trouvés.";
+        kbart.setErrorType(errorString);
+        if (isForced) {
+            log.error(FUNCTIONAL, errorString + " [ " + kbart + " ]");
+            return new BestPpn("", DESTINATION_TOPIC.BEST_PPN_BACON);
+        }
+        throw new BestPpnException(errorString + " [ " + kbart + " ] ");
+    }
+
+    private BestPpn unresolvedElectronicTie(
+            LigneKbartDto kbart,
+            Map<String, Integer> ppnElecScore,
+            boolean isForced) throws BestPpnException {
+        String listPpn = String.join(" OU ", ppnElecScore.keySet());
+        String errorString = "Plusieurs ppn électroniques ("
+                + listPpn
+                + ") ont le même score.";
+        kbart.setErrorType(errorString);
+        if (isForced) {
+            log.error(FUNCTIONAL, errorString + " [ " + kbart + " ]");
+            return new BestPpn("", DESTINATION_TOPIC.BEST_PPN_BACON);
+        }
+        throw new BestPpnException(errorString + " [ " + kbart + " ]");
+    }
+```
+
+- [ ] **Step 4: Adapt the existing Spring test fixture**
+
+Dans `src/test/java/fr/abes/bestppn/service/BestPpnServiceTest.java`, ajouter :
+
+```java
+import fr.abes.bestppn.model.tiebreak.TieBreakDecision;
+```
+
+Ajouter le mock suivant aux autres `@MockitoBean` :
+
+```java
+    @MockitoBean
+    BestPpnTieBreakerService tieBreakerService;
+```
+
+À la fin de `init()`, ajouter le comportement indécidable par défaut :
+
+```java
+        Mockito.when(tieBreakerService.resolve(
+                        Mockito.any(),
+                        Mockito.anyString(),
+                        Mockito.anyMap()))
+                .thenReturn(TieBreakDecision.unresolved(
+                        Map.of(), "clés identiques"));
+```
+
+Remplacer les quatre appels directs existants :
+
+```java
+bestPpnService.getBestPpnByScore(
+        kbart, "", ppnElecResultList, ppnPrintResultList, false);
+```
+
+```java
+bestPpnService.getBestPpnByScore(
+        kbart, "", ppnElecResultList, ppnPrintResultList, false);
+```
+
+```java
+bestPpnService.getBestPpnByScore(
+        kbart, "", ppnElecResultList, ppnPrintResultList, true);
+```
+
+```java
+bestPpnService.getBestPpnByScore(
+        kbart, "", ppnElecResultList, ppnPrintResultList, true);
+```
+
+- [ ] **Step 5: Run the focused BestPpnService tests**
+
+Run:
+
+```powershell
+mvn "-Dtest=BestPpnServiceTieBreakTest" test
+```
+
+Expected: `Tests run: 4, Failures: 0, Errors: 0` puis `BUILD SUCCESS`.
+
+Run:
+
+```powershell
+mvn "-Dtest=BestPpnServiceTest" test
+```
+
+Expected: `BUILD SUCCESS`. Vérifier dans `target/surefire-reports/fr.abes.bestppn.service.BestPpnServiceTest.txt` que `Tests run` est strictement supérieur à zéro ; si la configuration Log4j/Kafka du dépôt empêche encore l’exécution de cette classe Spring, consigner ce défaut de socle sans modifier le périmètre SOA-501.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```powershell
+git add src/main/java/fr/abes/bestppn/service/BestPpnService.java src/test/java/fr/abes/bestppn/service/BestPpnServiceTest.java src/test/java/fr/abes/bestppn/service/BestPpnServiceTieBreakTest.java
+git -c user.name="Jerome Villiseck" -c user.email="jvk@abes.fr" commit -m "feat: intégrer le départage dans bestppn"
+```
+
+Expected: un commit contenant uniquement l’intégration et ses tests.
+
+---
+
+### Task 5: Non-régression du flux XML complet
+
+**Files:**
+
+- Create: `src/test/java/fr/abes/bestppn/service/BestPpnTieBreakerFlowTest.java`
+
+**Interfaces:**
+
+- Consumes: implémentation réelle de `CandidateMetadataExtractor` et `BestPpnTieBreakerService`.
+- Mocks: accès Oracle de `NoticeService` et accès BACON de `ProviderService`.
+- Proves: les quatre critères SOA-501 fonctionnent depuis les zones XML jusqu’au PPN sélectionné.
+
+- [ ] **Step 1: Write the end-to-end XML flow tests**
+
+Créer `src/test/java/fr/abes/bestppn/service/BestPpnTieBreakerFlowTest.java` :
+
+```java
+package fr.abes.bestppn.service;
+
+import fr.abes.bestppn.model.dto.kafka.LigneKbartDto;
+import fr.abes.bestppn.model.entity.bacon.Provider;
+import fr.abes.bestppn.model.entity.basexml.notice.Controlfield;
+import fr.abes.bestppn.model.entity.basexml.notice.Datafield;
+import fr.abes.bestppn.model.entity.basexml.notice.NoticeXml;
+import fr.abes.bestppn.model.entity.basexml.notice.SubField;
+import fr.abes.bestppn.model.tiebreak.TieBreakDecision;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BestPpnTieBreakerFlowTest {
+    @Mock
+    private NoticeService noticeService;
+    @Mock
+    private ProviderService providerService;
+
+    private BestPpnTieBreakerService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new BestPpnTieBreakerService(
+                noticeService,
+                providerService,
+                new CandidateMetadataExtractor());
+    }
+
+    @Test
+    void supportEnLigneGagneContreCdRom() throws IOException {
+        LigneKbartDto kbart = kbart("serial");
+        notices(
+                notice("100000001", "Ressource en ligne", null, null, null, null),
+                notice("100000002", "CD-ROM", null, null, null, null));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertTrue(decision.resolved());
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals("SUPPORT", decision.reason());
+    }
+
+    @Test
+    void casReel164581340EstClasseCommeCdRom() throws IOException {
+        LigneKbartDto kbart = kbart("serial");
+        NoticeXml physical = notice(
+                "164581340", "( CD-ROM)", null, null, null, null);
+        physical.getControlfields().get(1).setValue("Obx3");
+        physical.getDatafields().add(
+                field("531", "#", "b", "(CD-ROM)"));
+        when(noticeService.getNoticeByPpn("100000001")).thenReturn(
+                notice("100000001", "Ressource en ligne", null, null, null, null));
+        when(noticeService.getNoticeByPpn("164581340")).thenReturn(physical);
+        Map<String, Integer> candidates = new LinkedHashMap<>();
+        candidates.put("100000001", 10);
+        candidates.put("164581340", 10);
+
+        TieBreakDecision decision = service.resolve(kbart, "", candidates);
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals(0, decision.keys().get("164581340").supportRank());
+    }
+
+    @Test
+    void diffuseur214Indicateur2DepartageLesNotices() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        Provider provider = new Provider("CAIRN");
+        provider.setDisplayName("Cairn.info");
+        when(providerService.findByProvider("CAIRN"))
+                .thenReturn(Optional.of(provider));
+        notices(
+                notice("100000001", "Ressource en ligne", "Cairn.info", null, null, null),
+                notice("100000002", "Ressource en ligne", "Autre diffuseur", null, null, null));
+
+        TieBreakDecision decision = service.resolve(kbart, "CAIRN", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals("DIFFUSEUR", decision.reason());
+    }
+
+    @Test
+    void volume200hDepartageLesNotices() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setMonographVolume("Part II");
+        notices(
+                notice("100000001", "Ressource en ligne", null, "Tome 2", null, null),
+                notice("100000002", "Ressource en ligne", null, "Tome 3", null, null));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals("VOLUME", decision.reason());
+    }
+
+    @Test
+    void titreDePartie200iDepartageLesNotices() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setPublicationTitle("Traité complet - Méthodes numériques");
+        notices(
+                notice("100000001", "Ressource en ligne", null, null, "Méthodes numériques", null),
+                notice("100000002", "Ressource en ligne", null, null, "Autre partie", null));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals("VOLUME", decision.reason());
+    }
+
+    @Test
+    void annee100Et214DepartageLesNotices() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setDateMonographPublishedOnline("2021-01-01");
+        kbart.setDateMonographPublishedPrint("2020");
+        notices(
+                notice("100000001", "Ressource en ligne", null, null, null, 2021),
+                notice("100000002", "Ressource en ligne", null, null, null, 2020));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals("ANNÉE", decision.reason());
+    }
+
+    private void notices(NoticeXml first, NoticeXml second) throws IOException {
+        when(noticeService.getNoticeByPpn("100000001")).thenReturn(first);
+        when(noticeService.getNoticeByPpn("100000002")).thenReturn(second);
+    }
+
+    private static LigneKbartDto kbart(String publicationType) {
+        LigneKbartDto kbart = new LigneKbartDto();
+        kbart.setPublicationType(publicationType);
+        kbart.setPublicationTitle("Titre");
+        return kbart;
+    }
+
+    private static Map<String, Integer> ties() {
+        Map<String, Integer> candidates = new LinkedHashMap<>();
+        candidates.put("100000001", 10);
+        candidates.put("100000002", 10);
+        return candidates;
+    }
+
+    private static NoticeXml notice(
+            String ppn,
+            String support,
+            String distributor,
+            String volume,
+            String partTitle,
+            Integer year) {
+        NoticeXml notice = new NoticeXml();
+        notice.setLeader("     nam0 22        450 ");
+        notice.setControlfields(List.of(
+                controlfield("001", ppn),
+                controlfield("008", "Oax3")));
+
+        List<Datafield> fields = new ArrayList<>();
+        fields.add(field("530", " ", "b", support));
+        if (distributor != null) {
+            fields.add(field("214", "2", "c", distributor));
+        }
+        if (volume != null || partTitle != null) {
+            List<String> titleValues = new ArrayList<>();
+            if (volume != null) {
+                titleValues.add("h");
+                titleValues.add(volume);
+            }
+            if (partTitle != null) {
+                titleValues.add("i");
+                titleValues.add(partTitle);
+            }
+            fields.add(field(
+                    "200", " ", titleValues.toArray(String[]::new)));
+        }
+        if (year != null) {
+            fields.add(field(
+                    "100",
+                    " ",
+                    "a",
+                    "20240723d" + year + "    m  y0frey50      ba"));
+            fields.add(field("214", "0", "d", "[" + year + "]"));
+        }
+        notice.setDatafields(fields);
+        return notice;
+    }
+
+    private static Controlfield controlfield(String tag, String value) {
+        Controlfield field = new Controlfield();
+        field.setTag(tag);
+        field.setValue(value);
+        return field;
+    }
+
+    private static Datafield field(
+            String tag,
+            String ind2,
+            String... codeValues) {
+        Datafield field = new Datafield();
+        field.setTag(tag);
+        field.setInd1(" ");
+        field.setInd2(ind2);
+        List<SubField> subFields = new ArrayList<>();
+        for (int index = 0; index < codeValues.length; index += 2) {
+            if (codeValues[index + 1] != null) {
+                SubField subField = new SubField();
+                subField.setCode(codeValues[index]);
+                subField.setValue(codeValues[index + 1]);
+                subFields.add(subField);
+            }
+        }
+        field.setSubFields(subFields);
+        return field;
+    }
+}
+```
+
+- [ ] **Step 2: Run the complete-flow tests**
+
+Run:
+
+```powershell
+mvn "-Dtest=BestPpnTieBreakerFlowTest" test
+```
+
+Expected: `Tests run: 6, Failures: 0, Errors: 0` puis `BUILD SUCCESS`. Le test `casReel164581340EstClasseCommeCdRom` reprend les valeurs `008=Obx3`, `530$b=( CD-ROM)` et `531$b=(CD-ROM)` lues dans la base APISUDOC de test.
+
+- [ ] **Step 3: Run every new SOA-501 test**
+
+Run:
+
+```powershell
+mvn "-Dtest=TieBreakNormalizerTest,CandidateDecisionKeyTest,CandidateMetadataExtractorTest,BestPpnTieBreakerServiceTest,BestPpnServiceTieBreakTest,BestPpnTieBreakerFlowTest" test
+```
+
+Expected: `Tests run: 39, Failures: 0, Errors: 0` puis `BUILD SUCCESS`.
+
+- [ ] **Step 4: Run the complete project test suite**
+
+Run:
+
+```powershell
+mvn test
+```
+
+Expected: `BUILD SUCCESS`. Contrôler dans `target/surefire-reports` que chacune des six nouvelles classes affiche un nombre de tests strictement supérieur à zéro, sans échec ni erreur. Le défaut de socle déjà observé sur les anciennes classes Spring avec la configuration Kafka/Log4j doit être signalé séparément s’il persiste.
+
+- [ ] **Step 5: Verify diff hygiene**
+
+Run:
+
+```powershell
+git diff --check
+git status --short
+git diff -- src/main/java/fr/abes/LigneKbartConnect.java src/main/java/fr/abes/LigneKbartImprime.java
+```
+
+Expected:
+
+- aucune erreur de whitespace ;
+- seuls les fichiers explicitement prévus par le plan sont ajoutés ou modifiés ;
+- les deux fichiers Avro éventuellement régénérés restent hors index ;
+- aucun fichier de `sudoc-api` n’est modifié.
+
+- [ ] **Step 6: Commit Task 5**
+
+Run:
+
+```powershell
+git add src/test/java/fr/abes/bestppn/service/BestPpnTieBreakerFlowTest.java
+git -c user.name="Jerome Villiseck" -c user.email="jvk@abes.fr" commit -m "test: couvrir le flux complet de départage SOA-501"
+```
+
+Expected: un commit contenant uniquement le test de non-régression XML.
+
+- [ ] **Step 7: Record final branch state**
+
+Run:
+
+```powershell
+git log --oneline --decorate origin/develop..HEAD
+git status --short
+```
+
+Expected: le commit de conception, le commit du présent plan et les cinq commits d’implémentation apparaissent sur `SOA-501-affiner-departage-bestppn`. Les seuls changements non commités admis sont les deux sources Avro régénérées déjà identifiées.

--- a/docs/superpowers/specs/2026-07-23-soa-501-departage-bestppn-design.md
+++ b/docs/superpowers/specs/2026-07-23-soa-501-departage-bestppn-design.md
@@ -1,0 +1,505 @@
+# SOA-501 - Conception du départage des PPN ex aequo
+
+## Statut
+
+Approche fonctionnelle validée le 23 juillet 2026.
+Spécification écrite en attente de relecture et de validation.
+
+Sources fonctionnelles :
+
+- ticket Jira `SOA-501` - « Affiner bestppn » ;
+- document `Webservices_Convergence.pdf` ;
+- ticket lié `CDE-477` pour le cas des notices multivolumes.
+
+## Objectif
+
+Réduire les cas où `best-ppn-api` ne produit aucun `bestppn` parce que plusieurs
+PPN électroniques ont obtenu le même score maximal.
+
+Le départage doit traiter les quatre cas décrits par SOA-501 :
+
+1. ressource en ligne contre CD-ROM ou DVD-ROM ;
+2. diffuseurs différents ;
+3. volumes différents ;
+4. années de publication différentes.
+
+La sélection automatique reste conservatrice : une notice présentant une
+contradiction forte avec la ligne KBART ne doit pas être choisie.
+
+## Hors périmètre
+
+- modification des webservices de recherche de `sudoc-api` ;
+- modification des pondérations actuelles ;
+- correction de l'enchaînement des appels `dat2ppn` ;
+- contrôle du provider pour les publications en série ;
+- rapprochement approximatif de titres au-delà du titre de partie `200$i` ;
+- apprentissage automatique ou configuration dynamique des pondérations.
+
+L'écart entre la documentation et le code pour les deux dates `dat2ppn` fait
+l'objet d'un ticket séparé.
+
+## État actuel
+
+`BestPpnService` cumule les résultats de `onlineId2ppn`, `printId2ppn`,
+`doi2ppn` et, en dernier recours, `dat2ppn`.
+
+Les pondérations restent :
+
+- `onlineId2ppn` : 10 ;
+- `printId2ppn` avec rebond : 8 ;
+- `printId2ppn` sans rebond : 6 ;
+- `doi2ppn` : 15 ;
+- `dat2ppn` : 20.
+
+Lorsqu'un service renvoie plusieurs PPN, ses points sont divisés entre les PPN
+trouvés. Les points sont ensuite additionnés par PPN.
+
+Après extraction des PPN ayant le score maximal :
+
+- aucun PPN électronique : traitement actuel des PPN imprimés ;
+- un PPN électronique : sélection actuelle ;
+- plusieurs PPN électroniques : erreur d'égalité ou valeur vide en mode forcé.
+
+SOA-501 s'insère uniquement dans le troisième cas.
+
+## Décision d'architecture
+
+L'arbitrage est implémenté uniquement dans `best-ppn-api`.
+
+Cette application possède déjà :
+
+- les données KBART ;
+- le provider du package ;
+- les scores calculés ;
+- un accès en lecture à la base XML ;
+- `NoticeService` pour charger une notice par PPN ;
+- la table BACON `PROVIDER`, qui fournit le code et le `DISPLAY_NAME`.
+
+Le contrat JSON de `sudoc-api` reste inchangé. Aucun déploiement coordonné entre
+les deux applications n'est nécessaire.
+
+## Flux de traitement
+
+```text
+Recherche des candidats
+        |
+Calcul des scores existants
+        |
+Extraction des candidats au score maximal
+        |
+Un seul candidat --------------------------> bestPPN
+        |
+Plusieurs candidats
+        |
+Chargement des notices XML
+        |
+Calcul des rangs SUPPORT, DIFFUSEUR, VOLUME, ANNÉE
+        |
+Comparaison lexicographique
+        |
+Validation des contradictions fortes
+        |
+Candidat unique ---------------------------> bestPPN
+        |
+Toujours indécidable ----------------------> erreur actuelle inchangée
+```
+
+Les notices sont chargées uniquement pour les PPN ex aequo au score maximal.
+Une notice n'est chargée qu'une fois pendant le traitement de la ligne KBART.
+
+## Clé de décision
+
+Pour chaque PPN `p`, la clé suivante est construite :
+
+```text
+clé(p) = (
+    scoreActuel,
+    rangSupport,
+    rangDiffuseur,
+    rangVolume,
+    rangAnnée
+)
+```
+
+Les clés sont comparées lexicographiquement, de gauche à droite et par ordre
+décroissant.
+
+Le `scoreActuel` reste le premier élément. Un PPN dont le score initial est
+inférieur ne peut donc jamais revenir dans la sélection.
+
+L'implémentation peut aussi appliquer la comparaison sous forme de cascade :
+
+```text
+T0 = PPN ayant le score maximal
+T1 = PPN de T0 ayant le meilleur rang support
+T2 = PPN de T1 ayant le meilleur rang diffuseur
+T3 = PPN de T2 ayant le meilleur rang volume
+T4 = PPN de T3 ayant le meilleur rang année
+```
+
+Lorsqu'une étape attribue le même rang à tous les candidats, l'ensemble reste
+inchangé.
+
+## Métadonnées extraites d'une notice
+
+Une représentation interne immuable contient :
+
+- le PPN ;
+- le mode d'accès détaillé : `ONLINE`, `PHYSICAL` ou `UNKNOWN` ;
+- les valeurs normalisées des `214 #2$c` ;
+- les valeurs normalisées des `200$h` ;
+- les titres de partie normalisés des `200$i` ;
+- les années extraites de `100$a` et `214$d` ;
+- un indicateur signalant une notice introuvable, supprimée ou illisible.
+
+L'extraction reste indépendante de la ligne KBART. La comparaison avec KBART
+est réalisée ensuite par le service d'arbitrage.
+
+## Normalisation commune
+
+Les comparaisons textuelles appliquent :
+
+1. passage en minuscules ;
+2. décomposition Unicode et suppression des diacritiques ;
+3. remplacement de la ponctuation par des espaces ;
+4. réduction des espaces multiples ;
+5. suppression des espaces en début et fin.
+
+La normalisation ne doit pas supprimer les chiffres.
+
+## Critère SUPPORT
+
+### Sources
+
+- `530$b` ;
+- `531$b` ;
+- zone `215` et ses sous-zones descriptives ;
+- `008` uniquement comme indication générale.
+
+Le premier caractère `O` de `008` ne suffit pas à identifier un accès en
+ligne, car il couvre également des supports comme le CD-ROM.
+
+### Rangs
+
+| Situation | Rang |
+|---|---:|
+| Mention explicite d'un accès en ligne | 2 |
+| Mode d'accès absent, générique, hybride ou ambigu | 1 |
+| Mention explicite d'un CD-ROM, DVD-ROM ou autre support matériel | 0 |
+
+Exemples de marqueurs en ligne :
+
+- `online` ;
+- `en ligne` ;
+- `ressource en ligne` ;
+- `accès internet`.
+
+Exemples de marqueurs physiques :
+
+- `cd-rom` ou `cédérom` ;
+- `dvd-rom` ;
+- `disque optique`.
+
+Le libellé générique `électronique` ne suffit pas à produire le rang 2.
+
+Si une notice contient à la fois un marqueur en ligne et un marqueur physique,
+son rang est 1.
+
+### Contradiction forte
+
+Un candidat de rang support 0 ne peut jamais être sélectionné automatiquement
+pour une ligne KBART.
+
+## Critère DIFFUSEUR
+
+Ce critère s'applique uniquement aux monographies.
+
+### Sources
+
+Pour la ligne KBART :
+
+- code `PROVIDER` ;
+- `DISPLAY_NAME` associé dans la table BACON `PROVIDER`.
+
+Pour la notice :
+
+- zones `214` dont le second indicateur vaut `2` ;
+- sous-zones `214 #2$c`.
+
+Le contrôle général déjà réalisé pendant la recherche à partir de `035`,
+`210$c`, `214$c` et des URL `856/859$u` reste inchangé.
+
+Le booléen `providerPresent` ne sert pas directement au nouvel arbitrage. Il
+agrège plusieurs contrôles et peut valoir vrai lorsqu'un provider n'est pas
+référencé dans BACON.
+
+### Rangs
+
+| Situation | Rang |
+|---|---:|
+| Une `214 #2$c` correspond au code provider ou au `DISPLAY_NAME` | 2 |
+| Provider inconnu ou aucune `214 #2$c` exploitable | 1 |
+| Une `214 #2$c` existe mais désigne explicitement un autre diffuseur | 0 |
+
+Une seule correspondance suffit lorsque plusieurs `214 #2$c` existent.
+
+La correspondance utilise les valeurs normalisées. Pour les codes courts, le
+code provider doit correspondre à un mot complet ; le `DISPLAY_NAME` peut être
+recherché comme une expression normalisée.
+
+### Contradiction forte
+
+Le rang diffuseur 0 n'est pas une interdiction absolue. Une notice peut avoir
+été légitimement repêchée par son URL d'accès.
+
+## Critère VOLUME
+
+Ce critère s'applique uniquement aux monographies.
+
+### Sources
+
+Pour la ligne KBART :
+
+- `monograph_volume` ;
+- à défaut, une mention de volume explicitement extraite de
+  `publication_title`.
+
+Pour la notice :
+
+- `200$h` pour la désignation ou le numéro de partie ;
+- `200$i` pour le titre de partie.
+
+### Normalisation
+
+Les préfixes usuels sont retirés :
+
+- `tome` ;
+- `volume` et `vol` ;
+- `partie` et `part` ;
+- `band`.
+
+Les chiffres romains simples sont convertis en chiffres arabes. Ainsi `2`,
+`02`, `Tome 2`, `Vol. 2` et `Part II` produisent la même clé `2`.
+
+### Rangs
+
+| Situation | Rang |
+|---|---:|
+| `monograph_volume` correspond exactement à `200$h` | 3 |
+| `200$i` correspond au titre de partie contenu dans le titre KBART | 2 |
+| La ligne KBART ne permet pas d'identifier un volume | 1 |
+| Volume explicitement différent ou notice d'ensemble sans `200$h/$i` alors que KBART décrit un volume | 0 |
+
+Si aucun volume fiable n'est disponible dans KBART, la seule présence de
+`200$h` ou `200$i` ne suffit pas à choisir un candidat.
+
+### Contradiction forte
+
+Lorsqu'un volume est explicite dans KBART, un candidat de rang volume 0 ne peut
+pas être sélectionné automatiquement.
+
+## Critère ANNÉE
+
+Ce critère s'applique uniquement aux monographies.
+
+### Sources
+
+Pour la ligne KBART, par priorité :
+
+1. `date_monograph_published_online` ;
+2. `date_monograph_published_print`.
+
+Pour la notice :
+
+- date 1 codée dans `100$a` ;
+- années présentes dans les `214$d`.
+
+Les formes `2021`, `DL 2021`, `cop. 2021` et `[2021]` produisent l'année
+normalisée `2021`.
+
+### Rangs
+
+| Situation | Rang |
+|---|---:|
+| Une année Sudoc correspond à la date KBART en ligne | 3 |
+| Aucune correspondance en ligne, mais correspondance avec la date imprimée | 2 |
+| Aucune année Sudoc fiable ou données internes contradictoires | 1 |
+| Les années Sudoc sont explicites et ne correspondent à aucune date KBART | 0 |
+
+Une notice ne reçoit le rang 0 que lorsque ses différentes sources de date ne
+se contredisent pas entre elles.
+
+### Contradiction forte
+
+Lorsque l'année KBART est explicite et que les années Sudoc sont cohérentes, un
+candidat de rang année 0 ne peut pas être sélectionné automatiquement.
+
+## Publications en série
+
+Pour une publication en série :
+
+- le critère support est évalué ;
+- diffuseur, volume et année reçoivent le rang neutre 1.
+
+Les contrôles supplémentaires sur les séries nécessitent une spécification
+fonctionnelle distincte.
+
+## Validation finale
+
+Le candidat ayant la meilleure clé n'est sélectionné que si :
+
+```text
+rangSupport != 0
+ET rangVolume != 0 lorsqu'un volume KBART est explicite
+ET rangAnnée != 0 lorsque les dates KBART et Sudoc sont explicites et cohérentes
+```
+
+S'il existe plusieurs meilleures clés identiques, ou si le meilleur candidat
+échoue à cette validation, l'erreur d'égalité actuelle est conservée.
+
+Le mode forcé conserve également son comportement actuel : le `bestppn` reste
+vide lorsque l'arbitrage n'aboutit pas.
+
+## Composants
+
+### `BestPpnService`
+
+- conserve la recherche et le calcul du score ;
+- transmet au service d'arbitrage la ligne KBART, le provider et les PPN ex
+  aequo ;
+- applique le résultat avant de produire l'erreur actuelle.
+
+### `BestPpnTieBreakerService`
+
+- orchestre l'arbitrage ;
+- charge les notices par `NoticeService` ;
+- récupère le code provider et le `DISPLAY_NAME` ;
+- calcule les quatre rangs ;
+- compare les clés ;
+- applique les contradictions fortes ;
+- produit une décision détaillée pour les logs.
+
+### `CandidateMetadataExtractor`
+
+- transforme une `NoticeXml` en métadonnées normalisées ;
+- ne dépend ni de Kafka, ni de la base BACON, ni du calcul des scores ;
+- se teste avec des notices XML construites en mémoire.
+
+### Modèles internes
+
+- `CandidateMetadata` : métadonnées extraites de la notice ;
+- `CandidateDecisionKey` : rangs calculés et comparaison lexicographique ;
+- `TieBreakDecision` : PPN sélectionné ou absence de décision, avec motif.
+
+## Gestion des erreurs
+
+- notice absente, supprimée ou illisible : métadonnées inconnues, sans arrêt du
+  traitement ;
+- provider absent de BACON : rang diffuseur neutre 1 ;
+- zone mal formée : critère concerné neutre 1 ;
+- exception d'accès à la base XML : journalisation technique, puis conservation
+  de l'égalité ;
+- aucune règle discriminante : erreur fonctionnelle actuelle.
+
+L'arbitrage ne doit jamais transformer un problème de lecture en sélection
+automatique.
+
+## Journalisation
+
+Pour chaque arbitrage :
+
+- liste des PPN ex aequo et score initial ;
+- valeurs KBART normalisées utilisées ;
+- clé calculée pour chaque candidat ;
+- zones ayant fourni les preuves ;
+- candidats éliminés à chaque critère ;
+- PPN retenu et critère décisif ;
+- motif de l'absence de décision.
+
+Exemple :
+
+```text
+Arbitrage SOA-501 : score=10, candidats=[123456789, 987654321]
+PPN 123456789 : support=2, diffuseur=2, volume=3, année=3
+PPN 987654321 : support=0, diffuseur=2, volume=3, année=3
+PPN retenu : 123456789, critère décisif : SUPPORT
+```
+
+## Performance
+
+- aucune notice XML n'est chargée en l'absence d'égalité ;
+- seuls les candidats ayant le score maximal sont chargés ;
+- chaque PPN est chargé une fois par ligne KBART ;
+- aucun nouveau webservice n'est appelé ;
+- aucune nouvelle dépendance n'est ajoutée.
+
+Une optimisation par chargement groupé n'est envisagée que si les mesures de
+production montrent que les lectures unitaires sont insuffisantes.
+
+## Stratégie de tests
+
+### Tests unitaires de l'extracteur
+
+- support en ligne ;
+- CD-ROM et DVD-ROM ;
+- support absent ou hybride ;
+- plusieurs `214`, dont une `214 #2$c` ;
+- `200$h` numérique et en chiffres romains ;
+- `200$i` correspondant au titre de partie ;
+- extraction de `100$a` ;
+- extraction de plusieurs `214$d` ;
+- zones absentes et mal formées.
+
+### Tests unitaires de l'arbitrage
+
+- chaque critère départage deux candidats ;
+- égalité inchangée lorsque le critère est neutre ;
+- ordre support, diffuseur, volume, année ;
+- score initial toujours prioritaire ;
+- veto sur support physique ;
+- veto sur volume incompatible ;
+- veto sur année explicitement incompatible ;
+- provider inconnu ;
+- publication en série ;
+- notice introuvable ;
+- mode forcé avec arbitrage impossible.
+
+### Tests d'intégration du service
+
+- un seul candidat conserve le comportement actuel ;
+- deux candidats départagés produisent un `BestPpn` électronique ;
+- deux candidats non départagés produisent l'erreur actuelle ;
+- aucun changement pour les parcours sans égalité ;
+- aucun changement pour la sélection d'un PPN imprimé.
+
+### Corpus de non-régression
+
+Les exemples commentés de SOA-501 et les cas historiques issus des fichiers
+`.bad` sont transformés en tests paramétrés après validation fonctionnelle du
+PPN attendu.
+
+## Critères d'acceptation
+
+1. Les pondérations et recherches existantes ne changent pas.
+2. L'arbitrage n'est exécuté que pour plusieurs PPN électroniques au score
+   maximal.
+3. Les quatre cas SOA-501 disposent de tests automatisés.
+4. Un support physique n'est jamais sélectionné pour une ligne KBART.
+5. Une contradiction forte empêche la sélection automatique.
+6. Une égalité non résolue conserve exactement le comportement actuel.
+7. Les logs expliquent le résultat sans nécessiter de recalcul manuel.
+8. Le contrat de `sudoc-api` reste inchangé.
+9. Aucun changement n'est apporté au comportement de `dat2ppn`.
+
+## Stratégie Git
+
+Dépôt concerné : `best-ppn-api`.
+
+Branche :
+
+```text
+SOA-501-affiner-departage-bestppn
+```
+
+La branche part de `origin/develop` et utilise un worktree dédié. Les commits
+sont rédigés en français et attribués à `Jerome Villiseck`.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>fr.abes</groupId>
     <artifactId>best-ppn-api</artifactId>
-    <version>1.2.5</version>
+    <version>1.2.6-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>best-ppn-api</name>
     <description>Api de calcul du best ppn pour bacon</description>

--- a/src/main/java/fr/abes/bestppn/model/tiebreak/AccessMode.java
+++ b/src/main/java/fr/abes/bestppn/model/tiebreak/AccessMode.java
@@ -1,0 +1,7 @@
+package fr.abes.bestppn.model.tiebreak;
+
+public enum AccessMode {
+    ONLINE,
+    PHYSICAL,
+    UNKNOWN
+}

--- a/src/main/java/fr/abes/bestppn/model/tiebreak/AccessMode.java
+++ b/src/main/java/fr/abes/bestppn/model/tiebreak/AccessMode.java
@@ -1,7 +1,26 @@
 package fr.abes.bestppn.model.tiebreak;
 
+/**
+ * Décrit le mode d'accès déduit des mentions explicites d'une notice Sudoc.
+ *
+ * <p>Cette information alimente le premier critère de départage de SOA-501.
+ * Elle ne reprend pas directement le type électronique de la zone 008, car
+ * cette zone peut également désigner un CD-ROM ou un DVD-ROM.</p>
+ */
 public enum AccessMode {
+    /**
+     * La notice contient une mention explicite d'accès en ligne.
+     */
     ONLINE,
+
+    /**
+     * La notice décrit explicitement un support matériel, par exemple un
+     * CD-ROM, un DVD-ROM ou un disque optique.
+     */
     PHYSICAL,
+
+    /**
+     * Le support est absent, générique, hybride ou contradictoire.
+     */
     UNKNOWN
 }

--- a/src/main/java/fr/abes/bestppn/model/tiebreak/CandidateDecisionKey.java
+++ b/src/main/java/fr/abes/bestppn/model/tiebreak/CandidateDecisionKey.java
@@ -2,6 +2,20 @@ package fr.abes.bestppn.model.tiebreak;
 
 import java.util.Comparator;
 
+/**
+ * Porte les valeurs utilisées pour comparer deux PPN candidats.
+ *
+ * <p>La comparaison est lexicographique et décroissante selon l'ordre métier
+ * suivant : score existant, SUPPORT, DIFFUSEUR, VOLUME, ANNÉE. Un critère de
+ * rang inférieur n'est donc consulté que si tous les critères précédents sont
+ * égaux.</p>
+ *
+ * @param currentScore score produit par l'algorithme bestppn existant
+ * @param supportRank rang SUPPORT, de 0 à 2
+ * @param distributorRank rang DIFFUSEUR, de 0 à 2
+ * @param volumeRank rang VOLUME, de 0 à 3
+ * @param yearRank rang ANNÉE, de 0 à 3
+ */
 public record CandidateDecisionKey(
         int currentScore,
         int supportRank,
@@ -9,6 +23,9 @@ public record CandidateDecisionKey(
         int volumeRank,
         int yearRank) implements Comparable<CandidateDecisionKey> {
 
+    /**
+     * Comparateur commun qui matérialise l'ordre strict des critères.
+     */
     private static final Comparator<CandidateDecisionKey> COMPARATOR =
             Comparator.comparingInt(CandidateDecisionKey::currentScore)
                     .thenComparingInt(CandidateDecisionKey::supportRank)
@@ -16,11 +33,30 @@ public record CandidateDecisionKey(
                     .thenComparingInt(CandidateDecisionKey::volumeRank)
                     .thenComparingInt(CandidateDecisionKey::yearRank);
 
+    /**
+     * Compare cette clé à une autre en appliquant l'ordre métier.
+     *
+     * @param other clé du candidat à comparer
+     * @return une valeur positive si cette clé est préférable, zéro si les
+     * clés sont identiques, une valeur négative sinon
+     */
     @Override
     public int compareTo(CandidateDecisionKey other) {
         return COMPARATOR.compare(this, other);
     }
 
+    /**
+     * Indique si la clé contient une incompatibilité qui interdit toute
+     * sélection automatique.
+     *
+     * <p>Les contradictions fortes concernent uniquement un support physique,
+     * un volume explicitement incompatible ou une année explicitement
+     * incompatible. Un rang DIFFUSEUR égal à 0 n'est volontairement pas un
+     * veto, car le candidat peut avoir été retenu grâce à son URL.</p>
+     *
+     * @return {@code true} si le candidat doit être rejeté malgré sa position
+     * dans l'ordre lexicographique
+     */
     public boolean hasStrongContradiction() {
         return supportRank == 0 || volumeRank == 0 || yearRank == 0;
     }

--- a/src/main/java/fr/abes/bestppn/model/tiebreak/CandidateDecisionKey.java
+++ b/src/main/java/fr/abes/bestppn/model/tiebreak/CandidateDecisionKey.java
@@ -1,0 +1,27 @@
+package fr.abes.bestppn.model.tiebreak;
+
+import java.util.Comparator;
+
+public record CandidateDecisionKey(
+        int currentScore,
+        int supportRank,
+        int distributorRank,
+        int volumeRank,
+        int yearRank) implements Comparable<CandidateDecisionKey> {
+
+    private static final Comparator<CandidateDecisionKey> COMPARATOR =
+            Comparator.comparingInt(CandidateDecisionKey::currentScore)
+                    .thenComparingInt(CandidateDecisionKey::supportRank)
+                    .thenComparingInt(CandidateDecisionKey::distributorRank)
+                    .thenComparingInt(CandidateDecisionKey::volumeRank)
+                    .thenComparingInt(CandidateDecisionKey::yearRank);
+
+    @Override
+    public int compareTo(CandidateDecisionKey other) {
+        return COMPARATOR.compare(this, other);
+    }
+
+    public boolean hasStrongContradiction() {
+        return supportRank == 0 || volumeRank == 0 || yearRank == 0;
+    }
+}

--- a/src/main/java/fr/abes/bestppn/model/tiebreak/CandidateMetadata.java
+++ b/src/main/java/fr/abes/bestppn/model/tiebreak/CandidateMetadata.java
@@ -1,0 +1,56 @@
+package fr.abes.bestppn.model.tiebreak;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public record CandidateMetadata(
+        String ppn,
+        AccessMode accessMode,
+        Set<String> distributors,
+        Set<String> volumeNumbers,
+        Set<String> partTitles,
+        Set<Integer> yearsFrom100,
+        Set<Integer> yearsFrom214,
+        List<String> evidence,
+        boolean unreadable) {
+
+    public CandidateMetadata {
+        distributors = immutableSet(distributors);
+        volumeNumbers = immutableSet(volumeNumbers);
+        partTitles = immutableSet(partTitles);
+        yearsFrom100 = immutableSet(yearsFrom100);
+        yearsFrom214 = immutableSet(yearsFrom214);
+        evidence = evidence == null ? List.of() : List.copyOf(evidence);
+    }
+
+    public static CandidateMetadata unreadable(String ppn, String reason) {
+        return new CandidateMetadata(
+                ppn,
+                AccessMode.UNKNOWN,
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                List.of(reason),
+                true);
+    }
+
+    public Set<Integer> allYears() {
+        Set<Integer> years = new LinkedHashSet<>(yearsFrom100);
+        years.addAll(yearsFrom214);
+        return Collections.unmodifiableSet(years);
+    }
+
+    public boolean hasContradictoryYears() {
+        return allYears().size() > 1;
+    }
+
+    private static <T> Set<T> immutableSet(Set<T> values) {
+        return values == null
+                ? Set.of()
+                : Collections.unmodifiableSet(new LinkedHashSet<>(values));
+    }
+}

--- a/src/main/java/fr/abes/bestppn/model/tiebreak/CandidateMetadata.java
+++ b/src/main/java/fr/abes/bestppn/model/tiebreak/CandidateMetadata.java
@@ -5,6 +5,28 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Représente les informations normalisées extraites d'une notice Sudoc pour
+ * l'arbitrage SOA-501.
+ *
+ * <p>Ce modèle ne contient aucune comparaison avec la ligne KBART. Il décrit
+ * uniquement ce qui a pu être lu dans la notice XML. Toutes les collections
+ * sont copiées défensivement afin que les données d'un candidat restent
+ * immuables pendant l'arbitrage.</p>
+ *
+ * @param ppn identifiant PPN du candidat
+ * @param accessMode mode d'accès déduit des zones descriptives du support
+ * @param distributors valeurs normalisées des sous-zones {@code 214 #2$c}
+ * @param volumeNumbers numéros de volume normalisés extraits des
+ * sous-zones {@code 200$h}
+ * @param partTitles titres de partie normalisés extraits des
+ * sous-zones {@code 200$i}
+ * @param yearsFrom100 années extraites de la date 1 codée dans {@code 100$a}
+ * @param yearsFrom214 années extraites des sous-zones {@code 214$d}
+ * @param evidence valeurs XML brutes ayant servi à construire les métadonnées,
+ * destinées à la journalisation
+ * @param unreadable indique que la notice est absente, supprimée ou illisible
+ */
 public record CandidateMetadata(
         String ppn,
         AccessMode accessMode,
@@ -16,6 +38,13 @@ public record CandidateMetadata(
         List<String> evidence,
         boolean unreadable) {
 
+    /**
+     * Construit des métadonnées immuables.
+     *
+     * <p>Une collection {@code null} est remplacée par une collection vide.
+     * Les autres collections sont copiées pour empêcher toute modification
+     * après la construction.</p>
+     */
     public CandidateMetadata {
         distributors = immutableSet(distributors);
         volumeNumbers = immutableSet(volumeNumbers);
@@ -25,6 +54,18 @@ public record CandidateMetadata(
         evidence = evidence == null ? List.of() : List.copyOf(evidence);
     }
 
+    /**
+     * Construit la représentation neutre d'une notice qui ne peut pas être
+     * exploitée.
+     *
+     * <p>Les rangs seront calculés à partir de valeurs inconnues et le service
+     * d'arbitrage conservera l'égalité au lieu de sélectionner
+     * accidentellement un autre candidat.</p>
+     *
+     * @param ppn identifiant du candidat concerné
+     * @param reason raison technique ou fonctionnelle de l'absence de données
+     * @return métadonnées vides marquées comme illisibles
+     */
     public static CandidateMetadata unreadable(String ppn, String reason) {
         return new CandidateMetadata(
                 ppn,
@@ -38,16 +79,37 @@ public record CandidateMetadata(
                 true);
     }
 
+    /**
+     * Regroupe les années provenant des zones 100 et 214.
+     *
+     * @return ensemble immuable de toutes les années Sudoc du candidat
+     */
     public Set<Integer> allYears() {
         Set<Integer> years = new LinkedHashSet<>(yearsFrom100);
         years.addAll(yearsFrom214);
         return Collections.unmodifiableSet(years);
     }
 
+    /**
+     * Détecte une incohérence interne entre les dates de la notice.
+     *
+     * <p>Plus d'une année distincte rend le critère ANNÉE neutre : le service
+     * ne peut pas déterminer laquelle constitue la date de référence.</p>
+     *
+     * @return {@code true} lorsque plusieurs années distinctes ont été
+     * extraites
+     */
     public boolean hasContradictoryYears() {
         return allYears().size() > 1;
     }
 
+    /**
+     * Transforme un ensemble éventuellement nul en copie immuable.
+     *
+     * @param values valeurs à protéger
+     * @param <T> type des valeurs
+     * @return ensemble vide si l'entrée est nulle, copie immuable sinon
+     */
     private static <T> Set<T> immutableSet(Set<T> values) {
         return values == null
                 ? Set.of()

--- a/src/main/java/fr/abes/bestppn/model/tiebreak/TieBreakDecision.java
+++ b/src/main/java/fr/abes/bestppn/model/tiebreak/TieBreakDecision.java
@@ -4,17 +4,44 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * Décrit le résultat complet d'une tentative de départage.
+ *
+ * <p>Une décision résolue contient un PPN sélectionné et le nom du critère
+ * décisif. Une décision indécidable conserve un PPN nul et explique pourquoi
+ * l'erreur d'égalité existante doit être maintenue.</p>
+ *
+ * @param selectedPpn PPN retenu, ou {@code null} lorsque l'arbitrage échoue
+ * @param keys clés calculées pour chaque candidat, utilisées dans les logs et
+ * les tests de diagnostic
+ * @param reason critère décisif pour une sélection, ou motif de l'absence de
+ * décision
+ */
 public record TieBreakDecision(
         String selectedPpn,
         Map<String, CandidateDecisionKey> keys,
         String reason) {
 
+    /**
+     * Protège la table des clés contre les modifications après construction.
+     *
+     * <p>Une table nulle est remplacée par une table vide. Une
+     * {@link LinkedHashMap} conserve l'ordre déterministe des candidats.</p>
+     */
     public TieBreakDecision {
         keys = keys == null
                 ? Map.of()
                 : Collections.unmodifiableMap(new LinkedHashMap<>(keys));
     }
 
+    /**
+     * Fabrique une décision résolue.
+     *
+     * @param ppn PPN sélectionné
+     * @param keys clés de tous les candidats comparés
+     * @param decisiveCriterion premier critère ayant rendu le candidat unique
+     * @return décision contenant le PPN retenu
+     */
     public static TieBreakDecision selected(
             String ppn,
             Map<String, CandidateDecisionKey> keys,
@@ -22,12 +49,24 @@ public record TieBreakDecision(
         return new TieBreakDecision(ppn, keys, decisiveCriterion);
     }
 
+    /**
+     * Fabrique une décision indécidable.
+     *
+     * @param keys clés calculées avant de constater l'égalité ou le veto
+     * @param reason motif expliquant l'absence de sélection automatique
+     * @return décision sans PPN sélectionné
+     */
     public static TieBreakDecision unresolved(
             Map<String, CandidateDecisionKey> keys,
             String reason) {
         return new TieBreakDecision(null, keys, reason);
     }
 
+    /**
+     * Indique si l'arbitrage a produit un PPN exploitable.
+     *
+     * @return {@code true} lorsque {@link #selectedPpn()} n'est pas nul
+     */
     public boolean resolved() {
         return selectedPpn != null;
     }

--- a/src/main/java/fr/abes/bestppn/model/tiebreak/TieBreakDecision.java
+++ b/src/main/java/fr/abes/bestppn/model/tiebreak/TieBreakDecision.java
@@ -1,0 +1,34 @@
+package fr.abes.bestppn.model.tiebreak;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public record TieBreakDecision(
+        String selectedPpn,
+        Map<String, CandidateDecisionKey> keys,
+        String reason) {
+
+    public TieBreakDecision {
+        keys = keys == null
+                ? Map.of()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(keys));
+    }
+
+    public static TieBreakDecision selected(
+            String ppn,
+            Map<String, CandidateDecisionKey> keys,
+            String decisiveCriterion) {
+        return new TieBreakDecision(ppn, keys, decisiveCriterion);
+    }
+
+    public static TieBreakDecision unresolved(
+            Map<String, CandidateDecisionKey> keys,
+            String reason) {
+        return new TieBreakDecision(null, keys, reason);
+    }
+
+    public boolean resolved() {
+        return selectedPpn != null;
+    }
+}

--- a/src/main/java/fr/abes/bestppn/service/BestPpnService.java
+++ b/src/main/java/fr/abes/bestppn/service/BestPpnService.java
@@ -6,6 +6,7 @@ import fr.abes.bestppn.model.BestPpn;
 import fr.abes.bestppn.model.dto.kafka.LigneKbartDto;
 import fr.abes.bestppn.model.dto.wscall.NoticeSummaryDto;
 import fr.abes.bestppn.model.dto.wscall.ResultWsSudocDto;
+import fr.abes.bestppn.model.tiebreak.TieBreakDecision;
 import fr.abes.bestppn.utils.*;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -20,40 +21,115 @@ import java.util.*;
 import static fr.abes.bestppn.utils.LogMarkers.FUNCTIONAL;
 import static fr.abes.bestppn.utils.LogMarkers.TECHNICAL;
 
+/**
+ * Orchestre la recherche, la notation et la sélection du meilleur PPN pour
+ * une ligne KBART.
+ *
+ * <p>Les candidats sont collectés à partir des identifiants en ligne et
+ * imprimé, du DOI, puis de {@code dat2ppn} en dernier recours pour les
+ * monographies. Les PPN électroniques reçoivent les scores historiques. Si
+ * plusieurs candidats partagent le score maximal, le service délègue leur
+ * départage à {@link BestPpnTieBreakerService}.</p>
+ */
 @Service
 @Getter
 @Slf4j
 public class BestPpnService {
+    /**
+     * Client des webservices Sudoc utilisés pour rechercher les candidats.
+     */
     private final WsService service;
+
+    /**
+     * Poids attribué aux PPN électroniques trouvés par l'identifiant en ligne.
+     */
     @Value("${score.online.id.to.ppn.elect}")
     private int scoreOnlineId2PpnElect;
 
+    /**
+     * Poids attribué aux PPN électroniques obtenus par rebond depuis
+     * l'identifiant imprimé.
+     */
     @Value("${score.print.id.to.ppn.elect}")
     private int scorePrintId2PpnElect;
 
+    /**
+     * Poids attribué aux PPN électroniques trouvés directement depuis
+     * l'identifiant imprimé.
+     */
     @Value("${score.error.type.notice}")
     private int scorePrintId2PpnElectNotByRebound;
 
+    /**
+     * Poids attribué aux PPN électroniques trouvés à partir du DOI.
+     */
     @Value("${score.doi.to.ppn}")
     private int scoreDoi2Ppn;
 
+    /**
+     * Poids attribué aux PPN électroniques trouvés par {@code dat2ppn}.
+     */
     @Value("${score.dat.to.ppn}")
     private int scoreDat2Ppn;
 
-    private final NoticeService noticeService;
+    /**
+     * Moteur SOA-501 chargé de départager les meilleurs scores ex aequo.
+     */
+    private final BestPpnTieBreakerService tieBreakerService;
 
+    /**
+     * Producteur Kafka conservé dans le contrat d'injection historique du
+     * service et exposé par le getter Lombok.
+     */
     private final TopicProducer topicProducer;
 
+    /**
+     * Vérifie qu'une URL KBART est présente dans une notice candidate.
+     */
     private final CheckUrlService checkUrlService;
 
-
-    public BestPpnService(WsService service, NoticeService noticeService, TopicProducer topicProducer, CheckUrlService checkUrlService) {
+    /**
+     * Construit l'orchestrateur avec ses services de recherche, de contrôle et
+     * d'arbitrage.
+     *
+     * @param service client des webservices Sudoc
+     * @param topicProducer producteur Kafka du traitement bestppn
+     * @param checkUrlService service de contrôle des URL dans les notices
+     * @param tieBreakerService moteur de départage des PPN ex aequo
+     */
+    public BestPpnService(
+            WsService service,
+            TopicProducer topicProducer,
+            CheckUrlService checkUrlService,
+            BestPpnTieBreakerService tieBreakerService) {
         this.service = service;
-        this.noticeService = noticeService;
         this.topicProducer = topicProducer;
         this.checkUrlService = checkUrlService;
+        this.tieBreakerService = tieBreakerService;
     }
 
+    /**
+     * Recherche tous les PPN candidats d'une ligne KBART et sélectionne le
+     * meilleur résultat.
+     *
+     * <p>Le fournisseur est ignoré pour les publications en série. Les
+     * recherches sont effectuées par identifiant en ligne, identifiant
+     * imprimé et DOI. Pour une monographie sans résultat, {@code dat2ppn} sert
+     * de dernier recours. Le fournisseur effectivement utilisé est transmis à
+     * {@link #getBestPpnByScore(LigneKbartDto, String, Map, Set, boolean)}
+     * afin d'alimenter le critère DIFFUSEUR de SOA-501.</p>
+     *
+     * @param kbart ligne KBART à traiter
+     * @param provider code du fournisseur BACON
+     * @param isForced {@code true} pour produire un résultat vide plutôt
+     * qu'une exception lorsqu'une égalité reste indécidable
+     * @return PPN retenu et destination fonctionnelle associée
+     * @throws IOException en cas d'échec de lecture d'une notice
+     * @throws BestPpnException en cas d'échec métier ou d'égalité non forcée
+     * @throws URISyntaxException si une URL candidate est invalide
+     * @throws RestClientException en cas d'échec d'un webservice
+     * @throws IllegalArgumentException si une donnée d'entrée est invalide
+     */
     public BestPpn getBestPpn(LigneKbartDto kbart, String provider, boolean isForced) throws IOException, BestPpnException, URISyntaxException, RestClientException, IllegalArgumentException {
         Map<String, Integer> ppnElecScoredList = new HashMap<>();
         Set<String> ppnPrintResultList = new HashSet<>();
@@ -78,9 +154,27 @@ public class BestPpnService {
             feedPpnListFromDat(kbart, ppnElecScoredList, ppnPrintResultList, provider);
         }
 
-        return getBestPpnByScore(kbart, ppnElecScoredList, ppnPrintResultList, isForced);
+        return getBestPpnByScore(
+                kbart,
+                provider,
+                ppnElecScoredList,
+                ppnPrintResultList,
+                isForced);
     }
 
+    /**
+     * Ajoute aux collections de candidats les résultats trouvés à partir de
+     * l'identifiant en ligne.
+     *
+     * @param kbart ligne KBART contenant l'identifiant
+     * @param provider fournisseur transmis au webservice
+     * @param ppnElecScoredList scores électroniques à compléter
+     * @param ppnPrintResultList PPN imprimés à compléter
+     * @throws IOException en cas d'échec de lecture associé au contrôle d'URL
+     * @throws URISyntaxException si l'URL KBART est invalide
+     * @throws IllegalArgumentException si l'appel reçoit une donnée invalide
+     * @throws BestPpnException si le webservice Sudoc échoue
+     */
     private void feedPpnListFromOnline(LigneKbartDto kbart, String provider, Map<String, Integer> ppnElecScoredList, Set<String> ppnPrintResultList) throws IOException, URISyntaxException, IllegalArgumentException, BestPpnException {
         log.debug(TECHNICAL, "Entrée dans onlineId2Ppn");
         try {
@@ -93,6 +187,19 @@ public class BestPpnService {
         }
     }
 
+    /**
+     * Ajoute aux collections de candidats les résultats directs et par rebond
+     * trouvés à partir de l'identifiant imprimé.
+     *
+     * @param kbart ligne KBART contenant l'identifiant
+     * @param provider fournisseur transmis au webservice
+     * @param ppnElecScoredList scores électroniques à compléter
+     * @param ppnPrintResultList PPN imprimés à compléter
+     * @throws IOException en cas d'échec de lecture associé au contrôle d'URL
+     * @throws URISyntaxException si l'URL KBART est invalide
+     * @throws IllegalArgumentException si l'appel reçoit une donnée invalide
+     * @throws BestPpnException si le webservice Sudoc échoue
+     */
     private void feedPpnListFromPrint(LigneKbartDto kbart, String provider, Map<String, Integer> ppnElecScoredList, Set<String> ppnPrintResultList) throws IOException, URISyntaxException, IllegalArgumentException, BestPpnException {
         log.debug(TECHNICAL, "Entrée dans printId2Ppn");
         try {
@@ -118,6 +225,17 @@ public class BestPpnService {
         }
     }
 
+    /**
+     * Recherche des monographies par année, auteur, titre et fournisseur
+     * lorsque les autres stratégies n'ont retourné aucun candidat.
+     *
+     * @param kbart ligne KBART fournissant les critères bibliographiques
+     * @param ppnElecScoredList scores électroniques à compléter
+     * @param ppnPrintResultList PPN imprimés à compléter
+     * @param providerName fournisseur transmis à {@code dat2ppn}
+     * @throws IOException en cas d'échec de contrôle d'une notice
+     * @throws URISyntaxException si l'URL KBART est invalide
+     */
     private void feedPpnListFromDat(LigneKbartDto kbart, Map<String, Integer> ppnElecScoredList, Set<String> ppnPrintResultList, String providerName) throws IOException, URISyntaxException {
         log.debug(TECHNICAL, "Entrée dans dat2ppn");
         ResultWsSudocDto resultCallWs = new ResultWsSudocDto();
@@ -150,6 +268,16 @@ public class BestPpnService {
         }
     }
 
+    /**
+     * Ajoute aux collections de candidats les résultats trouvés à partir du
+     * DOI.
+     *
+     * @param doi DOI normalisé à rechercher
+     * @param provider fournisseur transmis au webservice
+     * @param ppnElecScoredList scores électroniques à compléter
+     * @param ppnPrintResultList PPN imprimés à compléter
+     * @throws BestPpnException si le webservice Sudoc échoue
+     */
     private void feedPpnListFromDoi(String doi, String provider, Map<String, Integer> ppnElecScoredList, Set<String> ppnPrintResultList) throws BestPpnException {
         log.debug(TECHNICAL, "Entrée dans doi2ppn");
         ResultWsSudocDto resultWS;
@@ -171,6 +299,21 @@ public class BestPpnService {
         }
     }
 
+    /**
+     * Répartit le score d'une réponse Sudoc entre ses PPN électroniques et
+     * alimente séparément la collection des PPN imprimés.
+     *
+     * <p>Une monographie électronique n'est retenue que si le fournisseur ou
+     * l'URL KBART est présent dans la notice.</p>
+     *
+     * @param noticeSummaryDtos notices retournées par le webservice
+     * @param titleUrl URL KBART utilisée pour valider une monographie
+     * @param score score global associé à la stratégie de recherche
+     * @param ppnElecResultList scores électroniques à compléter
+     * @param ppnPrintResultList PPN imprimés à compléter
+     * @throws URISyntaxException si l'URL KBART est invalide
+     * @throws IOException en cas d'échec de contrôle d'une notice
+     */
     private void setScoreToEveryPpnFromResultWS(List<NoticeSummaryDto> noticeSummaryDtos, String titleUrl, int score, Map<String, Integer> ppnElecResultList, Set<String> ppnPrintResultList) throws URISyntaxException, IOException {
         if (!noticeSummaryDtos.isEmpty()) {
             int nbPpnElec = (int) noticeSummaryDtos.stream().filter(ppnWithTypeDto -> ppnWithTypeDto.getTypeSupport().equals(TYPE_SUPPORT.ELECTRONIQUE)).count();
@@ -185,6 +328,17 @@ public class BestPpnService {
         }
     }
 
+    /**
+     * Ajoute au candidat sa part du score de la stratégie courante.
+     *
+     * <p>Si le PPN a déjà été trouvé par une autre stratégie, son nouveau score
+     * est cumulé avec le précédent.</p>
+     *
+     * @param score score global à répartir
+     * @param ppnElecScoredList scores électroniques à mettre à jour
+     * @param nbPpnElec nombre de PPN électroniques partageant le score
+     * @param ppn candidat auquel attribuer la part de score
+     */
     private void setScoreToPpnElect(int score, Map<String, Integer> ppnElecScoredList, int nbPpnElec, NoticeSummaryDto ppn) {
         if (!ppnElecScoredList.isEmpty() && ppnElecScoredList.containsKey(ppn.getPpn())) {
             Integer value = ppnElecScoredList.get(ppn.getPpn()) + (score / nbPpnElec);
@@ -196,53 +350,125 @@ public class BestPpnService {
         log.debug(TECHNICAL, "PPN Electronique : " + ppn + " / score : " + ppnElecScoredList.get(ppn.getPpn()));
     }
 
-    public BestPpn getBestPpnByScore(LigneKbartDto kbart, Map<String, Integer> ppnElecResultList, Set<String> ppnPrintResultList, boolean isForced) throws BestPpnException {
-        Map<String, Integer> ppnElecScore = Utils.getMaxValuesFromMap(ppnElecResultList);
+    /**
+     * Sélectionne le meilleur PPN à partir des scores déjà calculés.
+     *
+     * <p>Sans candidat électronique, la méthode conserve le traitement
+     * historique des PPN imprimés. Un maximum électronique unique est retenu
+     * directement. Plusieurs maxima déclenchent le moteur SOA-501 ; son PPN
+     * est utilisé uniquement lorsqu'il produit une décision résolue. Une
+     * décision indécidable conserve l'exception historique ou, en mode forcé,
+     * un PPN vide.</p>
+     *
+     * @param kbart ligne KBART à laquelle rattacher le résultat ou l'erreur
+     * @param provider code fournisseur utilisé par le critère DIFFUSEUR
+     * @param ppnElecResultList scores des PPN électroniques candidats
+     * @param ppnPrintResultList PPN imprimés candidats
+     * @param isForced {@code true} pour retourner un PPN vide en cas
+     * d'indécision
+     * @return meilleur PPN et destination associée
+     * @throws BestPpnException si plusieurs candidats restent possibles hors
+     * mode forcé
+     */
+    public BestPpn getBestPpnByScore(
+            LigneKbartDto kbart,
+            String provider,
+            Map<String, Integer> ppnElecResultList,
+            Set<String> ppnPrintResultList,
+            boolean isForced) throws BestPpnException {
+        Map<String, Integer> ppnElecScore =
+                Utils.getMaxValuesFromMap(ppnElecResultList);
         return switch (ppnElecScore.size()) {
             case 0 -> {
                 log.info(FUNCTIONAL, "Aucun ppn électronique trouvé. " + kbart);
                 yield switch (ppnPrintResultList.size()) {
                     case 0 -> {
                         kbart.setErrorType("Aucun ppn trouvé");
-                        yield new BestPpn(null, DESTINATION_TOPIC.NO_PPN_FOUND_SUDOC);
+                        yield new BestPpn(
+                                null, DESTINATION_TOPIC.NO_PPN_FOUND_SUDOC);
                     }
-
                     case 1 -> {
-                        String printPpn = ppnPrintResultList.stream().toList().getFirst();
-                        kbart.setErrorType("Ppn imprimé trouvé : " + printPpn);
+                        String printPpn =
+                                ppnPrintResultList.stream().toList().getFirst();
+                        kbart.setErrorType(
+                                "Ppn imprimé trouvé : " + printPpn);
                         log.debug(TECHNICAL, kbart.getErrorType());
-                        yield new BestPpn(printPpn, DESTINATION_TOPIC.PRINT_PPN_SUDOC, TYPE_SUPPORT.IMPRIME);
+                        yield new BestPpn(
+                                printPpn,
+                                DESTINATION_TOPIC.PRINT_PPN_SUDOC,
+                                TYPE_SUPPORT.IMPRIME);
                     }
-
-                    default -> {
-                        String errorString = "Plusieurs ppn imprimés (" + String.join(" OU ", ppnPrintResultList) + ") ont été trouvés.";
-                        kbart.setErrorType(errorString);
-                        // vérification du forçage
-                        if (isForced) {
-                            log.error(FUNCTIONAL, errorString + " [ " + kbart + " ]");
-                            yield new BestPpn("", DESTINATION_TOPIC.BEST_PPN_BACON);
-                        } else {
-                            throw new BestPpnException(errorString + " [ " + kbart + " ] ");
-                        }
-                    }
+                    default -> unresolvedPrintTie(
+                            kbart, ppnPrintResultList, isForced);
                 };
             }
-            case 1 ->
-                    new BestPpn(ppnElecScore.keySet().stream().findFirst().get(), DESTINATION_TOPIC.BEST_PPN_BACON, TYPE_SUPPORT.ELECTRONIQUE);
-
+            case 1 -> new BestPpn(
+                    ppnElecScore.keySet().stream().findFirst().orElseThrow(),
+                    DESTINATION_TOPIC.BEST_PPN_BACON,
+                    TYPE_SUPPORT.ELECTRONIQUE);
             default -> {
-                String listPpn = String.join(" OU ", ppnElecScore.keySet());
-                String errorString = "Plusieurs ppn électroniques (" + listPpn + ") ont le même score.";
-                kbart.setErrorType(errorString);
-                // vérification du forçage
-                if (isForced) {
-                    log.error(FUNCTIONAL, errorString + " [ " + kbart + " ]");
-                    yield new BestPpn("", DESTINATION_TOPIC.BEST_PPN_BACON);
-                } else {
-                    throw new BestPpnException(errorString + " [ " + kbart + " ]");
+                TieBreakDecision decision =
+                        tieBreakerService.resolve(kbart, provider, ppnElecScore);
+                if (decision.resolved()) {
+                    yield new BestPpn(
+                            decision.selectedPpn(),
+                            DESTINATION_TOPIC.BEST_PPN_BACON,
+                            TYPE_SUPPORT.ELECTRONIQUE);
                 }
+                yield unresolvedElectronicTie(
+                        kbart, ppnElecScore, isForced);
             }
         };
+    }
+
+    /**
+     * Produit le résultat historique d'une égalité entre PPN imprimés.
+     *
+     * @param kbart ligne KBART recevant le message d'erreur
+     * @param ppnPrintResultList PPN imprimés ex aequo
+     * @param isForced {@code true} pour retourner un PPN vide
+     * @return résultat vide destiné au topic bestppn en mode forcé
+     * @throws BestPpnException lorsque le traitement n'est pas forcé
+     */
+    private BestPpn unresolvedPrintTie(
+            LigneKbartDto kbart,
+            Set<String> ppnPrintResultList,
+            boolean isForced) throws BestPpnException {
+        String errorString = "Plusieurs ppn imprimés ("
+                + String.join(" OU ", ppnPrintResultList)
+                + ") ont été trouvés.";
+        kbart.setErrorType(errorString);
+        if (isForced) {
+            log.error(FUNCTIONAL, errorString + " [ " + kbart + " ]");
+            return new BestPpn("", DESTINATION_TOPIC.BEST_PPN_BACON);
+        }
+        throw new BestPpnException(errorString + " [ " + kbart + " ] ");
+    }
+
+    /**
+     * Produit le résultat historique d'une égalité électronique que SOA-501
+     * n'a pas pu résoudre.
+     *
+     * @param kbart ligne KBART recevant le message d'erreur
+     * @param ppnElecScore meilleurs scores électroniques ex aequo
+     * @param isForced {@code true} pour retourner un PPN vide
+     * @return résultat vide destiné au topic bestppn en mode forcé
+     * @throws BestPpnException lorsque le traitement n'est pas forcé
+     */
+    private BestPpn unresolvedElectronicTie(
+            LigneKbartDto kbart,
+            Map<String, Integer> ppnElecScore,
+            boolean isForced) throws BestPpnException {
+        String listPpn = String.join(" OU ", ppnElecScore.keySet());
+        String errorString = "Plusieurs ppn électroniques ("
+                + listPpn
+                + ") ont le même score.";
+        kbart.setErrorType(errorString);
+        if (isForced) {
+            log.error(FUNCTIONAL, errorString + " [ " + kbart + " ]");
+            return new BestPpn("", DESTINATION_TOPIC.BEST_PPN_BACON);
+        }
+        throw new BestPpnException(errorString + " [ " + kbart + " ]");
     }
 
 }

--- a/src/main/java/fr/abes/bestppn/service/BestPpnTieBreakerService.java
+++ b/src/main/java/fr/abes/bestppn/service/BestPpnTieBreakerService.java
@@ -1,0 +1,496 @@
+package fr.abes.bestppn.service;
+
+import fr.abes.bestppn.model.dto.kafka.LigneKbartDto;
+import fr.abes.bestppn.model.entity.bacon.Provider;
+import fr.abes.bestppn.model.entity.basexml.notice.NoticeXml;
+import fr.abes.bestppn.model.tiebreak.CandidateDecisionKey;
+import fr.abes.bestppn.model.tiebreak.CandidateMetadata;
+import fr.abes.bestppn.model.tiebreak.TieBreakDecision;
+import fr.abes.bestppn.utils.PUBLICATION_TYPE;
+import fr.abes.bestppn.utils.TieBreakNormalizer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.function.ToIntFunction;
+
+import static fr.abes.bestppn.utils.LogMarkers.FUNCTIONAL;
+import static fr.abes.bestppn.utils.LogMarkers.TECHNICAL;
+
+/**
+ * Départage les PPN restés ex aequo après le calcul de score historique de
+ * bestppn.
+ *
+ * <p>Le service charge une seule fois la notice XML de chaque candidat, en
+ * extrait les métadonnées utiles, puis construit une clé comparée dans l'ordre
+ * strict suivant : score existant, SUPPORT, DIFFUSEUR, VOLUME et ANNÉE. Pour
+ * les publications en série, seuls le score et le support participent
+ * réellement à l'arbitrage ; les trois derniers critères reçoivent un rang
+ * neutre.</p>
+ *
+ * <p>Une égalité parfaite, une notice illisible ou une contradiction forte
+ * sur le meilleur candidat conserve l'indécision initiale. Les contradictions
+ * fortes sont un support physique, un volume incompatible ou une année
+ * incompatible. Une divergence de diffuseur n'est pas un veto.</p>
+ */
+@Service
+@Slf4j
+public class BestPpnTieBreakerService {
+    /**
+     * Accès aux notices XML de la base Sudoc.
+     */
+    private final NoticeService noticeService;
+
+    /**
+     * Accès au référentiel BACON utilisé pour relier le code fournisseur
+     * KBART à son libellé de diffuseur.
+     */
+    private final ProviderService providerService;
+
+    /**
+     * Convertit une notice XML en métadonnées normalisées utilisables par les
+     * critères SUPPORT, DIFFUSEUR, VOLUME et ANNÉE.
+     */
+    private final CandidateMetadataExtractor extractor;
+
+    /**
+     * Construit le service d'arbitrage avec ses trois sources de données.
+     *
+     * @param noticeService service de lecture des notices XML
+     * @param providerService service de consultation des fournisseurs BACON
+     * @param extractor extracteur des métadonnées d'une notice candidate
+     */
+    public BestPpnTieBreakerService(
+            NoticeService noticeService,
+            ProviderService providerService,
+            CandidateMetadataExtractor extractor) {
+        this.noticeService = noticeService;
+        this.providerService = providerService;
+        this.extractor = extractor;
+    }
+
+    /**
+     * Tente de sélectionner un unique PPN parmi des candidats ex aequo.
+     *
+     * <p>Chaque notice est chargée exactement une fois. Les clés de décision
+     * sont ensuite comparées lexicographiquement dans l'ordre
+     * {@code SCORE > SUPPORT > DIFFUSEUR > VOLUME > ANNÉE}. La première étape
+     * de la cascade ne laissant qu'un candidat détermine le critère décisif
+     * enregistré dans la décision et dans les logs.</p>
+     *
+     * <p>L'arbitrage reste indécidable lorsqu'il y a moins de deux candidats,
+     * lorsqu'une notice ne peut pas être lue, lorsque plusieurs candidats
+     * possèdent la même meilleure clé ou lorsque le meilleur candidat présente
+     * une contradiction forte.</p>
+     *
+     * @param kbart ligne KBART à rapprocher ; elle doit être non nulle
+     * @param providerCode code fournisseur de la ligne KBART, éventuellement
+     * absent
+     * @param tiedCandidates PPN ex aequo associés à leur score bestppn
+     * existant
+     * @return décision résolue avec le PPN retenu ou décision indécidable avec
+     * son motif
+     */
+    public TieBreakDecision resolve(
+            LigneKbartDto kbart,
+            String providerCode,
+            Map<String, Integer> tiedCandidates) {
+        if (tiedCandidates == null || tiedCandidates.size() < 2) {
+            return TieBreakDecision.unresolved(Map.of(), "moins de deux candidats");
+        }
+
+        log.info(FUNCTIONAL,
+                "Arbitrage SOA-501 : candidats={}, scores={}",
+                tiedCandidates.keySet(),
+                tiedCandidates);
+
+        Optional<Provider> provider = findProvider(providerCode);
+        Map<String, CandidateMetadata> metadataByPpn = loadMetadata(tiedCandidates.keySet());
+        log.info(FUNCTIONAL,
+                "Arbitrage SOA-501 : KBART provider={}, titre={}, volume={}, annéeEnLigne={}, annéeImprimée={}",
+                TieBreakNormalizer.normalizeText(providerCode),
+                TieBreakNormalizer.normalizeText(kbart.getPublicationTitle()),
+                TieBreakNormalizer.normalizeVolume(kbart.getMonographVolume()).orElse(""),
+                TieBreakNormalizer.extractYear(kbart.getDateMonographPublishedOnline())
+                        .stream().boxed().findFirst().orElse(null),
+                TieBreakNormalizer.extractYear(kbart.getDateMonographPublishedPrint())
+                        .stream().boxed().findFirst().orElse(null));
+        Map<String, CandidateDecisionKey> keys = buildKeys(
+                kbart, provider.orElse(null), tiedCandidates, metadataByPpn);
+
+        keys.forEach((ppn, key) -> log.info(
+                FUNCTIONAL,
+                "Arbitrage SOA-501 : ppn={}, clé={}, preuves={}",
+                ppn,
+                key,
+                metadataByPpn.get(ppn).evidence()));
+
+        if (metadataByPpn.values().stream().anyMatch(CandidateMetadata::unreadable)) {
+            log.warn(FUNCTIONAL,
+                    "Arbitrage SOA-501 indécidable : notice absente, supprimée ou illisible");
+            return TieBreakDecision.unresolved(
+                    keys, "notice absente, supprimée ou illisible");
+        }
+
+        CandidateDecisionKey maxKey = keys.values().stream()
+                .max(Comparator.naturalOrder())
+                .orElseThrow();
+        List<String> winners = keys.entrySet().stream()
+                .filter(entry -> entry.getValue().equals(maxKey))
+                .map(Map.Entry::getKey)
+                .toList();
+
+        if (winners.size() != 1) {
+            log.warn(FUNCTIONAL,
+                    "Arbitrage SOA-501 indécidable : clés identiques pour {}",
+                    winners);
+            return TieBreakDecision.unresolved(keys, "clés identiques");
+        }
+
+        String winner = winners.getFirst();
+        String decisiveCriterion = logCascadeAndFindDecisiveCriterion(keys);
+        if (maxKey.hasStrongContradiction()) {
+            log.warn(FUNCTIONAL,
+                    "Arbitrage SOA-501 refusé : ppn={}, clé={}, contradiction forte",
+                    winner,
+                    maxKey);
+            return TieBreakDecision.unresolved(
+                    keys, "contradiction forte sur le meilleur candidat");
+        }
+
+        log.info(FUNCTIONAL,
+                "Arbitrage SOA-501 résolu : ppn={}, critère décisif={}",
+                winner,
+                decisiveCriterion);
+        return TieBreakDecision.selected(winner, keys, decisiveCriterion);
+    }
+
+    /**
+     * Recherche le fournisseur BACON correspondant au code reçu.
+     *
+     * <p>Un code absent, un fournisseur inconnu ou une erreur d'accès à BACON
+     * produit une valeur vide. Le critère DIFFUSEUR sera alors neutre et ne
+     * bloquera pas les autres critères.</p>
+     *
+     * @param providerCode code fournisseur provenant du traitement KBART
+     * @return fournisseur trouvé, ou valeur vide si la comparaison n'est pas
+     * possible
+     */
+    private Optional<Provider> findProvider(String providerCode) {
+        if (providerCode == null || providerCode.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            return providerService.findByProvider(providerCode);
+        } catch (RuntimeException exception) {
+            log.error(TECHNICAL,
+                    "Impossible de charger le provider {} pendant l'arbitrage SOA-501",
+                    providerCode,
+                    exception);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Charge et extrait les métadonnées de chaque candidat.
+     *
+     * <p>Les PPN sont parcourus dans l'ordre alphabétique afin de rendre les
+     * clés et les logs déterministes. Chaque PPN est lu une seule fois. Une
+     * erreur de lecture XML ou d'extraction est transformée en métadonnée
+     * illisible ; {@link #resolve(LigneKbartDto, String, Map)} préservera alors
+     * l'égalité au lieu de sélectionner un candidat sur des données
+     * incomplètes.</p>
+     *
+     * @param ppns ensemble des PPN à charger
+     * @return métadonnées indexées par PPN, y compris une entrée illisible en
+     * cas d'échec
+     */
+    private Map<String, CandidateMetadata> loadMetadata(Set<String> ppns) {
+        Map<String, CandidateMetadata> result = new LinkedHashMap<>();
+        ppns.stream().sorted().forEach(ppn -> {
+            try {
+                NoticeXml notice = noticeService.getNoticeByPpn(ppn);
+                result.put(ppn, extractor.extract(ppn, notice));
+            } catch (IOException | RuntimeException exception) {
+                log.error(TECHNICAL,
+                        "Impossible de charger la notice {} pendant l'arbitrage SOA-501",
+                        ppn,
+                        exception);
+                result.put(ppn, CandidateMetadata.unreadable(
+                        ppn, "erreur de lecture XML"));
+            }
+        });
+        return result;
+    }
+
+    /**
+     * Calcule la clé de décision complète de chaque candidat.
+     *
+     * <p>Le score initial est conservé tel quel. Les quatre rangs suivants sont
+     * calculés à partir de la ligne KBART, du fournisseur BACON et des
+     * métadonnées XML. L'insertion par PPN trié garantit un résultat
+     * déterministe.</p>
+     *
+     * @param kbart ligne KBART servant de référence
+     * @param provider fournisseur BACON, ou {@code null} s'il est inconnu
+     * @param tiedCandidates scores actuels indexés par PPN
+     * @param metadataByPpn métadonnées extraites indexées par PPN
+     * @return clés de décision indexées par PPN
+     */
+    private Map<String, CandidateDecisionKey> buildKeys(
+            LigneKbartDto kbart,
+            Provider provider,
+            Map<String, Integer> tiedCandidates,
+            Map<String, CandidateMetadata> metadataByPpn) {
+        Map<String, CandidateDecisionKey> keys = new LinkedHashMap<>();
+        tiedCandidates.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> {
+                    CandidateMetadata metadata = metadataByPpn.get(entry.getKey());
+                    keys.put(entry.getKey(), new CandidateDecisionKey(
+                            entry.getValue(),
+                            supportRank(metadata),
+                            distributorRank(kbart, provider, metadata),
+                            volumeRank(kbart, metadata),
+                            yearRank(kbart, metadata)));
+                });
+        return keys;
+    }
+
+    /**
+     * Attribue le rang SUPPORT d'un candidat.
+     *
+     * @param metadata métadonnées de la notice candidate
+     * @return {@code 2} pour une ressource en ligne, {@code 1} si le support
+     * est inconnu et {@code 0} pour un support physique ; ce dernier rang est
+     * une contradiction forte
+     */
+    private int supportRank(CandidateMetadata metadata) {
+        return switch (metadata.accessMode()) {
+            case ONLINE -> 2;
+            case UNKNOWN -> 1;
+            case PHYSICAL -> 0;
+        };
+    }
+
+    /**
+     * Attribue le rang DIFFUSEUR d'une monographie.
+     *
+     * <p>Le code ou le libellé BACON est recherché parmi les diffuseurs de la
+     * notice. Une correspondance vaut {@code 2}, l'absence de fournisseur ou
+     * de diffuseur vaut le rang neutre {@code 1}, et une divergence explicite
+     * vaut {@code 0}. Ce dernier rang reste un indice de départage et n'est pas
+     * une contradiction forte, car une URL peut justifier le candidat.</p>
+     *
+     * @param kbart ligne KBART servant à déterminer le type de publication
+     * @param provider fournisseur BACON, ou {@code null}
+     * @param metadata métadonnées de la notice candidate
+     * @return rang DIFFUSEUR entre 0 et 2, ou {@code 1} pour une publication en
+     * série
+     */
+    private int distributorRank(
+            LigneKbartDto kbart,
+            Provider provider,
+            CandidateMetadata metadata) {
+        if (!isMonograph(kbart)) {
+            return 1;
+        }
+        if (provider == null || metadata.distributors().isEmpty()) {
+            return 1;
+        }
+
+        String displayName = TieBreakNormalizer.normalizeText(provider.getDisplayName());
+        boolean match = metadata.distributors().stream().anyMatch(distributor ->
+                TieBreakNormalizer.containsWord(distributor, provider.getProvider())
+                        || (!displayName.isBlank()
+                        && (distributor.equals(displayName)
+                        || distributor.contains(displayName))));
+        return match ? 2 : 0;
+    }
+
+    /**
+     * Attribue le rang VOLUME d'une monographie.
+     *
+     * <p>Le volume attendu provient d'abord de {@code monograph_volume}, puis
+     * à défaut du titre KBART. Une correspondance exacte avec un numéro de
+     * volume de la notice vaut {@code 3}. Une correspondance du titre KBART
+     * avec un titre de partie issu du champ {@code 200$i} vaut {@code 2}.
+     * L'absence de volume exploitable vaut le rang neutre {@code 1}. Une
+     * divergence explicite vaut {@code 0} et constitue une contradiction
+     * forte.</p>
+     *
+     * @param kbart ligne KBART contenant le volume ou le titre attendu
+     * @param metadata métadonnées de la notice candidate
+     * @return rang VOLUME entre 0 et 3, ou {@code 1} pour une publication en
+     * série
+     */
+    private int volumeRank(LigneKbartDto kbart, CandidateMetadata metadata) {
+        if (!isMonograph(kbart)) {
+            return 1;
+        }
+
+        Optional<String> expectedVolume =
+                TieBreakNormalizer.normalizeVolume(kbart.getMonographVolume());
+        if (expectedVolume.isEmpty()) {
+            expectedVolume = TieBreakNormalizer.extractVolumeFromTitle(
+                    kbart.getPublicationTitle());
+        }
+
+        if (expectedVolume.isPresent()
+                && metadata.volumeNumbers().contains(expectedVolume.get())) {
+            return 3;
+        }
+
+        String normalizedTitle =
+                TieBreakNormalizer.normalizeText(kbart.getPublicationTitle());
+        boolean partTitleMatch = metadata.partTitles().stream()
+                .anyMatch(partTitle -> !partTitle.isBlank()
+                        && normalizedTitle.contains(partTitle));
+        if (partTitleMatch) {
+            return 2;
+        }
+
+        return expectedVolume.isEmpty() ? 1 : 0;
+    }
+
+    /**
+     * Attribue le rang ANNÉE d'une monographie.
+     *
+     * <p>Une correspondance avec l'année de publication en ligne vaut
+     * {@code 3} et prévaut sur la correspondance avec l'année imprimée, qui
+     * vaut {@code 2}. L'absence d'année KBART, l'absence d'année Sudoc ou des
+     * années contradictoires dans la notice donnent le rang neutre {@code 1}.
+     * Une divergence explicite vaut {@code 0} et constitue une contradiction
+     * forte.</p>
+     *
+     * @param kbart ligne KBART contenant les dates de publication
+     * @param metadata métadonnées et années extraites de la notice candidate
+     * @return rang ANNÉE entre 0 et 3, ou {@code 1} pour une publication en
+     * série
+     */
+    private int yearRank(LigneKbartDto kbart, CandidateMetadata metadata) {
+        if (!isMonograph(kbart)) {
+            return 1;
+        }
+
+        OptionalInt onlineYear = TieBreakNormalizer.extractYear(
+                kbart.getDateMonographPublishedOnline());
+        OptionalInt printYear = TieBreakNormalizer.extractYear(
+                kbart.getDateMonographPublishedPrint());
+        if (onlineYear.isEmpty() && printYear.isEmpty()) {
+            return 1;
+        }
+
+        Set<Integer> sudocYears = metadata.allYears();
+        if (sudocYears.isEmpty() || metadata.hasContradictoryYears()) {
+            return 1;
+        }
+        if (onlineYear.isPresent() && sudocYears.contains(onlineYear.getAsInt())) {
+            return 3;
+        }
+        if (printYear.isPresent() && sudocYears.contains(printYear.getAsInt())) {
+            return 2;
+        }
+        return 0;
+    }
+
+    /**
+     * Indique si les critères DIFFUSEUR, VOLUME et ANNÉE doivent être
+     * appliqués.
+     *
+     * @param kbart ligne KBART examinée
+     * @return {@code true} uniquement pour le type de publication
+     * {@link PUBLICATION_TYPE#MONOGRAPH}
+     */
+    private boolean isMonograph(LigneKbartDto kbart) {
+        return kbart != null
+                && PUBLICATION_TYPE.MONOGRAPH.name().equalsIgnoreCase(
+                kbart.getPublicationType());
+    }
+
+    /**
+     * Rejoue la cascade de comparaison pour tracer les éliminations et
+     * identifier le critère décisif.
+     *
+     * <p>Cette méthode ne recalcule pas le gagnant : elle parcourt les clés
+     * déjà établies et élimine, critère par critère, les candidats dont le rang
+     * est inférieur au maximum parmi les survivants.</p>
+     *
+     * @param keys clés de décision indexées par PPN
+     * @return nom du premier critère laissant un seul candidat, ou
+     * {@code AUCUN} si l'égalité subsiste
+     */
+    private String logCascadeAndFindDecisiveCriterion(
+            Map<String, CandidateDecisionKey> keys) {
+        List<String> survivors = new ArrayList<>(keys.keySet());
+        String decisive = "AUCUN";
+        decisive = decisiveAfterStep(
+                survivors, keys, CandidateDecisionKey::currentScore, "SCORE");
+        if (!decisive.equals("AUCUN")) {
+            return decisive;
+        }
+        decisive = decisiveAfterStep(
+                survivors, keys, CandidateDecisionKey::supportRank, "SUPPORT");
+        if (!decisive.equals("AUCUN")) {
+            return decisive;
+        }
+        decisive = decisiveAfterStep(
+                survivors, keys, CandidateDecisionKey::distributorRank, "DIFFUSEUR");
+        if (!decisive.equals("AUCUN")) {
+            return decisive;
+        }
+        decisive = decisiveAfterStep(
+                survivors, keys, CandidateDecisionKey::volumeRank, "VOLUME");
+        if (!decisive.equals("AUCUN")) {
+            return decisive;
+        }
+        return decisiveAfterStep(
+                survivors, keys, CandidateDecisionKey::yearRank, "ANNÉE");
+    }
+
+    /**
+     * Applique une étape de la cascade aux candidats encore en lice.
+     *
+     * <p>Les candidats sous le rang maximal sont retirés de la liste mutable
+     * des survivants et consignés dans les logs fonctionnels.</p>
+     *
+     * @param survivors PPN encore en lice ; la liste est modifiée par la
+     * méthode
+     * @param keys clés de décision indexées par PPN
+     * @param rank fonction extrayant le rang du critère courant
+     * @param criterion nom fonctionnel du critère pour les logs et la décision
+     * @return le nom du critère s'il ne reste qu'un candidat, sinon
+     * {@code AUCUN}
+     */
+    private String decisiveAfterStep(
+            List<String> survivors,
+            Map<String, CandidateDecisionKey> keys,
+            ToIntFunction<CandidateDecisionKey> rank,
+            String criterion) {
+        int max = survivors.stream()
+                .map(keys::get)
+                .mapToInt(rank)
+                .max()
+                .orElseThrow();
+        List<String> eliminated = survivors.stream()
+                .filter(ppn -> rank.applyAsInt(keys.get(ppn)) < max)
+                .toList();
+        survivors.removeAll(eliminated);
+        if (!eliminated.isEmpty()) {
+            log.info(FUNCTIONAL,
+                    "Arbitrage SOA-501 : critère={}, éliminés={}, restants={}",
+                    criterion,
+                    eliminated,
+                    survivors);
+        }
+        return survivors.size() == 1 ? criterion : "AUCUN";
+    }
+}

--- a/src/main/java/fr/abes/bestppn/service/CandidateMetadataExtractor.java
+++ b/src/main/java/fr/abes/bestppn/service/CandidateMetadataExtractor.java
@@ -1,0 +1,295 @@
+package fr.abes.bestppn.service;
+
+import fr.abes.bestppn.model.entity.basexml.notice.Controlfield;
+import fr.abes.bestppn.model.entity.basexml.notice.Datafield;
+import fr.abes.bestppn.model.entity.basexml.notice.NoticeXml;
+import fr.abes.bestppn.model.entity.basexml.notice.SubField;
+import fr.abes.bestppn.model.tiebreak.AccessMode;
+import fr.abes.bestppn.model.tiebreak.CandidateMetadata;
+import fr.abes.bestppn.utils.TieBreakNormalizer;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Extrait d'une notice UNIMARC XML les métadonnées nécessaires au départage
+ * SOA-501.
+ *
+ * <p>Ce composant ne compare pas les valeurs de la notice avec la ligne KBART
+ * et ne choisit aucun PPN. Il collecte et normalise les preuves utiles aux
+ * critères SUPPORT, DIFFUSEUR, VOLUME et ANNÉE, puis construit un
+ * {@link CandidateMetadata} immuable.</p>
+ *
+ * <p>L'extraction est défensive : les listes, zones et sous-zones absentes ou
+ * mal formées sont ignorées. Une notice absente ou supprimée est explicitement
+ * marquée comme illisible afin que le futur service d'arbitrage conserve
+ * l'égalité.</p>
+ */
+@Component
+public class CandidateMetadataExtractor {
+    /**
+     * Expressions normalisées considérées comme une preuve explicite d'accès
+     * en ligne dans les zones 530, 531 ou 215.
+     */
+    private static final List<String> ONLINE_MARKERS =
+            List.of("online", "en ligne", "ressource en ligne", "acces internet");
+
+    /**
+     * Expressions normalisées considérées comme une preuve explicite de
+     * support matériel dans les zones 530, 531 ou 215.
+     */
+    private static final List<String> PHYSICAL_MARKERS =
+            List.of("cd rom", "cederom", "dvd rom", "disque optique");
+
+    /**
+     * Transforme une notice XML en métadonnées normalisées.
+     *
+     * <p>Les zones traitées sont :</p>
+     *
+     * <ul>
+     *   <li>530$b, 531$b et toutes les sous-zones 215 pour le support ;</li>
+     *   <li>214 #2$c pour le diffuseur ;</li>
+     *   <li>200$h et 200$i pour le volume ou le titre de partie ;</li>
+     *   <li>100$a et 214$d pour les années.</li>
+     * </ul>
+     *
+     * <p>La zone 008 est conservée dans les preuves, mais ne suffit jamais à
+     * elle seule à produire le mode {@link AccessMode#ONLINE}.</p>
+     *
+     * @param ppn identifiant du candidat, utilisé même si la notice est
+     * absente
+     * @param notice notice UNIMARC désérialisée, éventuellement nulle
+     * @return métadonnées extraites, ou métadonnées illisibles si la notice
+     * est absente ou supprimée
+     */
+    public CandidateMetadata extract(String ppn, NoticeXml notice) {
+        if (notice == null) {
+            return CandidateMetadata.unreadable(ppn, "notice absente");
+        }
+        if (notice.getLeader() != null
+                && notice.getLeader().length() > 5
+                && notice.getLeader().charAt(5) == 'd') {
+            return CandidateMetadata.unreadable(ppn, "notice supprimée");
+        }
+
+        Set<String> supportValues = new LinkedHashSet<>();
+        Set<String> distributors = new LinkedHashSet<>();
+        Set<String> volumeNumbers = new LinkedHashSet<>();
+        Set<String> partTitles = new LinkedHashSet<>();
+        Set<Integer> yearsFrom100 = new LinkedHashSet<>();
+        Set<Integer> yearsFrom214 = new LinkedHashSet<>();
+        List<String> evidence = new ArrayList<>();
+
+        for (Controlfield controlfield : safeControlfields(notice)) {
+            if (controlfield != null && Objects.equals("008", controlfield.getTag())) {
+                addEvidence(evidence, "008", null, controlfield.getValue());
+            }
+        }
+
+        for (Datafield field : safeDatafields(notice)) {
+            if (field == null || field.getTag() == null) {
+                continue;
+            }
+            switch (field.getTag()) {
+                case "530", "531" -> values(field, "b").forEach(value -> {
+                    addNormalized(supportValues, value);
+                    addEvidence(evidence, field.getTag(), "b", value);
+                });
+                case "215" -> safeSubfields(field).forEach(subfield -> {
+                    addNormalized(supportValues, subfield.getValue());
+                    addEvidence(evidence, "215", subfield.getCode(), subfield.getValue());
+                });
+                case "214" -> extractPublicationField(
+                        field, distributors, yearsFrom214, evidence);
+                case "200" -> extractTitleField(
+                        field, volumeNumbers, partTitles, evidence);
+                case "100" -> values(field, "a").forEach(value -> {
+                    TieBreakNormalizer.extractDate1From100(value).ifPresent(yearsFrom100::add);
+                    addEvidence(evidence, "100", "a", value);
+                });
+                default -> {
+                }
+            }
+        }
+
+        return new CandidateMetadata(
+                ppn,
+                accessMode(supportValues),
+                distributors,
+                volumeNumbers,
+                partTitles,
+                yearsFrom100,
+                yearsFrom214,
+                evidence,
+                false);
+    }
+
+    /**
+     * Extrait d'une zone 214 les années de publication et, lorsque le second
+     * indicateur vaut 2, les diffuseurs.
+     *
+     * @param field zone 214 à analyser
+     * @param distributors ensemble recevant les valeurs normalisées de 214$c
+     * @param years ensemble recevant les années trouvées dans 214$d
+     * @param evidence liste recevant les valeurs brutes utilisées
+     */
+    private void extractPublicationField(
+            Datafield field,
+            Set<String> distributors,
+            Set<Integer> years,
+            List<String> evidence) {
+        values(field, "d").forEach(value -> {
+            years.addAll(TieBreakNormalizer.extractYears(value));
+            addEvidence(evidence, "214", "d", value);
+        });
+        if (Objects.equals("2", field.getInd2())) {
+            values(field, "c").forEach(value -> {
+                addNormalized(distributors, value);
+                addEvidence(evidence, "214", "c", value);
+            });
+        }
+    }
+
+    /**
+     * Extrait d'une zone 200 les numéros et titres de partie.
+     *
+     * <p>Les valeurs 200$h sont converties en clés de volume numériques. Les
+     * valeurs 200$i sont seulement normalisées afin de permettre leur
+     * comparaison ultérieure avec le titre KBART.</p>
+     *
+     * @param field zone 200 à analyser
+     * @param volumeNumbers ensemble recevant les volumes normalisés
+     * @param partTitles ensemble recevant les titres de partie normalisés
+     * @param evidence liste recevant les valeurs brutes utilisées
+     */
+    private void extractTitleField(
+            Datafield field,
+            Set<String> volumeNumbers,
+            Set<String> partTitles,
+            List<String> evidence) {
+        values(field, "h").forEach(value -> {
+            TieBreakNormalizer.normalizeVolume(value).ifPresent(volumeNumbers::add);
+            addEvidence(evidence, "200", "h", value);
+        });
+        values(field, "i").forEach(value -> {
+            addNormalized(partTitles, value);
+            addEvidence(evidence, "200", "i", value);
+        });
+    }
+
+    /**
+     * Détermine le mode d'accès à partir des mentions descriptives
+     * normalisées.
+     *
+     * @param supportValues mentions extraites de 530$b, 531$b et 215
+     * @return {@link AccessMode#ONLINE} pour une preuve en ligne seule,
+     * {@link AccessMode#PHYSICAL} pour une preuve physique seule, ou
+     * {@link AccessMode#UNKNOWN} si les preuves sont absentes ou
+     * contradictoires
+     */
+    private AccessMode accessMode(Set<String> supportValues) {
+        boolean online = containsMarker(supportValues, ONLINE_MARKERS);
+        boolean physical = containsMarker(supportValues, PHYSICAL_MARKERS);
+        if (online == physical) {
+            return AccessMode.UNKNOWN;
+        }
+        return online ? AccessMode.ONLINE : AccessMode.PHYSICAL;
+    }
+
+    /**
+     * Vérifie si au moins une valeur contient l'un des marqueurs attendus.
+     *
+     * @param values valeurs normalisées de la notice
+     * @param markers expressions normalisées recherchées
+     * @return {@code true} dès qu'une expression est trouvée
+     */
+    private boolean containsMarker(Set<String> values, List<String> markers) {
+        return values.stream().anyMatch(value ->
+                markers.stream().anyMatch(value::contains));
+    }
+
+    /**
+     * Retourne les valeurs non vides d'une sous-zone donnée.
+     *
+     * @param field zone contenant les sous-zones
+     * @param code code de sous-zone recherché
+     * @return liste des valeurs brutes correspondantes
+     */
+    private List<String> values(Datafield field, String code) {
+        return safeSubfields(field).stream()
+                .filter(subfield -> Objects.equals(code, subfield.getCode()))
+                .map(SubField::getValue)
+                .filter(Objects::nonNull)
+                .filter(value -> !value.isBlank())
+                .toList();
+    }
+
+    /**
+     * Protège le parcours des zones d'une notice.
+     *
+     * @param notice notice en cours d'extraction
+     * @return liste des zones, ou liste vide si elle est absente
+     */
+    private List<Datafield> safeDatafields(NoticeXml notice) {
+        return notice.getDatafields() == null ? List.of() : notice.getDatafields();
+    }
+
+    /**
+     * Protège le parcours des zones de contrôle d'une notice.
+     *
+     * @param notice notice en cours d'extraction
+     * @return liste des zones de contrôle, ou liste vide si elle est absente
+     */
+    private List<Controlfield> safeControlfields(NoticeXml notice) {
+        return notice.getControlfields() == null ? List.of() : notice.getControlfields();
+    }
+
+    /**
+     * Protège le parcours des sous-zones et écarte les éléments nuls issus
+     * d'un XML mal formé.
+     *
+     * @param field zone en cours d'extraction
+     * @return liste non nulle de sous-zones exploitables
+     */
+    private List<SubField> safeSubfields(Datafield field) {
+        return field.getSubFields() == null
+                ? List.of()
+                : field.getSubFields().stream()
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    /**
+     * Normalise une valeur textuelle avant de l'ajouter à un ensemble.
+     *
+     * @param target ensemble de destination
+     * @param value valeur brute à normaliser
+     */
+    private void addNormalized(Set<String> target, String value) {
+        String normalized = TieBreakNormalizer.normalizeText(value);
+        if (!normalized.isBlank()) {
+            target.add(normalized);
+        }
+    }
+
+    /**
+     * Conserve la provenance et la valeur brute d'une preuve.
+     *
+     * <p>Le format produit est {@code zone$sous-zone=valeur}, ou
+     * {@code zone=valeur} pour une zone de contrôle.</p>
+     *
+     * @param evidence liste de preuves à enrichir
+     * @param tag étiquette UNIMARC
+     * @param code code de sous-zone, ou {@code null} pour une zone de contrôle
+     * @param value valeur brute
+     */
+    private void addEvidence(List<String> evidence, String tag, String code, String value) {
+        if (value != null && !value.isBlank()) {
+            evidence.add(tag + (code == null ? "" : "$" + code) + "=" + value);
+        }
+    }
+}

--- a/src/main/java/fr/abes/bestppn/utils/TieBreakNormalizer.java
+++ b/src/main/java/fr/abes/bestppn/utils/TieBreakNormalizer.java
@@ -9,22 +9,72 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Fournit les normalisations communes aux critères de départage SOA-501.
+ *
+ * <p>Cette classe sans état transforme les valeurs KBART et UNIMARC en formes
+ * comparables. Elle ne décide jamais quel PPN doit être retenu.</p>
+ */
 public final class TieBreakNormalizer {
+    /**
+     * Identifie les signes diacritiques produits par la décomposition Unicode.
+     */
     private static final Pattern DIACRITICS = Pattern.compile("\\p{M}+");
+
+    /**
+     * Identifie toute ponctuation à remplacer par un séparateur.
+     */
     private static final Pattern NON_ALPHANUMERIC = Pattern.compile("[^\\p{L}\\p{N}]+");
+
+    /**
+     * Identifie les suites d'espaces à réduire à un espace unique.
+     */
     private static final Pattern SPACES = Pattern.compile("\\s+");
+
+    /**
+     * Identifie une année comprise entre 1800 et 2199 sans l'extraire d'un
+     * nombre plus long.
+     */
     private static final Pattern YEAR = Pattern.compile("(?<!\\d)(?:18|19|20|21)\\d{2}(?!\\d)");
+
+    /**
+     * Identifie une désignation de volume isolée, avec ou sans préfixe usuel.
+     */
     private static final Pattern VOLUME = Pattern.compile(
             "^(?:(?:tome|volume|vol|partie|part|band)\\s*)?([0-9]+|[ivxlcdm]+)(?:\\s.*)?$",
             Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Identifie dans un titre une désignation de volume précédée d'un préfixe
+     * explicite.
+     */
     private static final Pattern VOLUME_IN_TITLE = Pattern.compile(
             "(?:^|\\s)(?:tome|volume|vol|partie|part|band)\\s+([0-9]+|[ivxlcdm]+)(?:\\s|$)",
             Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Limite la conversion romaine aux symboles autorisés.
+     */
     private static final Pattern VALID_ROMAN = Pattern.compile("[IVXLCDM]+");
 
+    /**
+     * Empêche l'instanciation d'une classe composée uniquement de méthodes
+     * statiques.
+     */
     private TieBreakNormalizer() {
     }
 
+    /**
+     * Produit une forme textuelle comparable.
+     *
+     * <p>La méthode passe le texte en minuscules, retire les diacritiques,
+     * remplace la ponctuation par des espaces et réduit les espaces multiples.
+     * Les lettres et les chiffres sont conservés. Une valeur nulle produit une
+     * chaîne vide.</p>
+     *
+     * @param value texte KBART ou UNIMARC
+     * @return texte normalisé, jamais nul
+     */
     public static String normalizeText(String value) {
         if (value == null) {
             return "";
@@ -35,11 +85,28 @@ public final class TieBreakNormalizer {
         return SPACES.matcher(withoutPunctuation.toLowerCase(Locale.ROOT).trim()).replaceAll(" ");
     }
 
+    /**
+     * Extrait la première année explicite d'une valeur libre.
+     *
+     * @param value date ou mention de publication
+     * @return année trouvée, ou résultat vide si aucune année valide n'existe
+     */
     public static OptionalInt extractYear(String value) {
         Matcher matcher = YEAR.matcher(value == null ? "" : value);
         return matcher.find() ? OptionalInt.of(Integer.parseInt(matcher.group())) : OptionalInt.empty();
     }
 
+    /**
+     * Extrait la date 1 de la sous-zone UNIMARC {@code 100$a}.
+     *
+     * <p>La date de saisie occupe les huit premiers caractères, suivie du code
+     * de type de date. La date 1 est donc lue aux index 9 à 12 inclus. Une
+     * valeur trop courte ou une année hors de l'intervalle 1800-2199 produit
+     * un résultat vide.</p>
+     *
+     * @param value contenu brut de {@code 100$a}
+     * @return date 1 sous forme d'année
+     */
     public static OptionalInt extractDate1From100(String value) {
         if (value == null || value.length() < 13) {
             return OptionalInt.empty();
@@ -50,6 +117,12 @@ public final class TieBreakNormalizer {
                 : OptionalInt.empty();
     }
 
+    /**
+     * Extrait toutes les années distinctes d'une valeur libre.
+     *
+     * @param value mention de publication pouvant contenir plusieurs années
+     * @return ensemble des années trouvées
+     */
     public static Set<Integer> extractYears(String value) {
         Set<Integer> years = new LinkedHashSet<>();
         Matcher matcher = YEAR.matcher(value == null ? "" : value);
@@ -59,6 +132,17 @@ public final class TieBreakNormalizer {
         return Set.copyOf(years);
     }
 
+    /**
+     * Normalise une désignation de volume.
+     *
+     * <p>Les préfixes {@code tome}, {@code volume}, {@code vol},
+     * {@code partie}, {@code part} et {@code band} sont ignorés. Les zéros de
+     * tête sont supprimés et un nombre romain canonique est converti en nombre
+     * arabe. Une désignation non reconnue produit un résultat vide.</p>
+     *
+     * @param value désignation brute du volume
+     * @return clé numérique normalisée sous forme de chaîne
+     */
     public static Optional<String> normalizeVolume(String value) {
         String normalized = normalizeText(value);
         Matcher matcher = VOLUME.matcher(normalized);
@@ -72,11 +156,32 @@ public final class TieBreakNormalizer {
         return romanToArabic(token).map(String::valueOf);
     }
 
+    /**
+     * Recherche une désignation explicite de volume dans un titre.
+     *
+     * <p>Un préfixe de volume est obligatoire afin de ne pas interpréter un
+     * nombre appartenant normalement au titre comme un numéro de partie.</p>
+     *
+     * @param title titre de publication KBART
+     * @return volume normalisé trouvé dans le titre
+     */
     public static Optional<String> extractVolumeFromTitle(String title) {
         Matcher matcher = VOLUME_IN_TITLE.matcher(normalizeText(title));
         return matcher.find() ? normalizeVolume(matcher.group(1)) : Optional.empty();
     }
 
+    /**
+     * Vérifie la présence d'un code comme mot ou expression complète.
+     *
+     * <p>Les deux valeurs sont normalisées avant la comparaison. Les bornes
+     * évitent notamment qu'un code provider court comme {@code cairn}
+     * corresponde à {@code cairninfo}.</p>
+     *
+     * @param text texte dans lequel effectuer la recherche
+     * @param word code ou expression recherchée
+     * @return {@code true} si la valeur recherchée est délimitée par le début,
+     * la fin ou des espaces
+     */
     public static boolean containsWord(String text, String word) {
         String normalizedText = normalizeText(text);
         String normalizedWord = normalizeText(word);
@@ -87,6 +192,15 @@ public final class TieBreakNormalizer {
         return completeWord.matcher(normalizedText).find();
     }
 
+    /**
+     * Convertit un nombre romain canonique en nombre arabe.
+     *
+     * <p>La reconversion du résultat vers sa forme romaine permet de refuser
+     * les écritures non canoniques telles que {@code IIII}.</p>
+     *
+     * @param value nombre romain à convertir
+     * @return valeur arabe, ou résultat vide si l'écriture n'est pas canonique
+     */
     private static Optional<Integer> romanToArabic(String value) {
         String roman = value.toUpperCase(Locale.ROOT);
         if (!VALID_ROMAN.matcher(roman).matches()) {
@@ -102,6 +216,12 @@ public final class TieBreakNormalizer {
         return total > 0 && toRoman(total).equals(roman) ? Optional.of(total) : Optional.empty();
     }
 
+    /**
+     * Retourne la valeur élémentaire d'un symbole romain.
+     *
+     * @param value symbole romain
+     * @return valeur du symbole, ou 0 pour un caractère inconnu
+     */
     private static int romanValue(char value) {
         return switch (value) {
             case 'I' -> 1;
@@ -115,6 +235,12 @@ public final class TieBreakNormalizer {
         };
     }
 
+    /**
+     * Produit la représentation romaine canonique d'un entier positif.
+     *
+     * @param value valeur arabe à convertir
+     * @return représentation romaine canonique
+     */
     private static String toRoman(int value) {
         int[] arabic = {1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1};
         String[] roman = {"M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"};

--- a/src/main/java/fr/abes/bestppn/utils/TieBreakNormalizer.java
+++ b/src/main/java/fr/abes/bestppn/utils/TieBreakNormalizer.java
@@ -1,0 +1,131 @@
+package fr.abes.bestppn.utils;
+
+import java.text.Normalizer;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class TieBreakNormalizer {
+    private static final Pattern DIACRITICS = Pattern.compile("\\p{M}+");
+    private static final Pattern NON_ALPHANUMERIC = Pattern.compile("[^\\p{L}\\p{N}]+");
+    private static final Pattern SPACES = Pattern.compile("\\s+");
+    private static final Pattern YEAR = Pattern.compile("(?<!\\d)(?:18|19|20|21)\\d{2}(?!\\d)");
+    private static final Pattern VOLUME = Pattern.compile(
+            "^(?:(?:tome|volume|vol|partie|part|band)\\s*)?([0-9]+|[ivxlcdm]+)(?:\\s.*)?$",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern VOLUME_IN_TITLE = Pattern.compile(
+            "(?:^|\\s)(?:tome|volume|vol|partie|part|band)\\s+([0-9]+|[ivxlcdm]+)(?:\\s|$)",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern VALID_ROMAN = Pattern.compile("[IVXLCDM]+");
+
+    private TieBreakNormalizer() {
+    }
+
+    public static String normalizeText(String value) {
+        if (value == null) {
+            return "";
+        }
+        String decomposed = Normalizer.normalize(value, Normalizer.Form.NFD);
+        String withoutDiacritics = DIACRITICS.matcher(decomposed).replaceAll("");
+        String withoutPunctuation = NON_ALPHANUMERIC.matcher(withoutDiacritics).replaceAll(" ");
+        return SPACES.matcher(withoutPunctuation.toLowerCase(Locale.ROOT).trim()).replaceAll(" ");
+    }
+
+    public static OptionalInt extractYear(String value) {
+        Matcher matcher = YEAR.matcher(value == null ? "" : value);
+        return matcher.find() ? OptionalInt.of(Integer.parseInt(matcher.group())) : OptionalInt.empty();
+    }
+
+    public static OptionalInt extractDate1From100(String value) {
+        if (value == null || value.length() < 13) {
+            return OptionalInt.empty();
+        }
+        String date1 = value.substring(9, 13);
+        return date1.matches("(?:18|19|20|21)\\d{2}")
+                ? OptionalInt.of(Integer.parseInt(date1))
+                : OptionalInt.empty();
+    }
+
+    public static Set<Integer> extractYears(String value) {
+        Set<Integer> years = new LinkedHashSet<>();
+        Matcher matcher = YEAR.matcher(value == null ? "" : value);
+        while (matcher.find()) {
+            years.add(Integer.parseInt(matcher.group()));
+        }
+        return Set.copyOf(years);
+    }
+
+    public static Optional<String> normalizeVolume(String value) {
+        String normalized = normalizeText(value);
+        Matcher matcher = VOLUME.matcher(normalized);
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
+        String token = matcher.group(1);
+        if (token.chars().allMatch(Character::isDigit)) {
+            return Optional.of(Integer.toString(Integer.parseInt(token)));
+        }
+        return romanToArabic(token).map(String::valueOf);
+    }
+
+    public static Optional<String> extractVolumeFromTitle(String title) {
+        Matcher matcher = VOLUME_IN_TITLE.matcher(normalizeText(title));
+        return matcher.find() ? normalizeVolume(matcher.group(1)) : Optional.empty();
+    }
+
+    public static boolean containsWord(String text, String word) {
+        String normalizedText = normalizeText(text);
+        String normalizedWord = normalizeText(word);
+        if (normalizedWord.isBlank()) {
+            return false;
+        }
+        Pattern completeWord = Pattern.compile("(^|\\s)" + Pattern.quote(normalizedWord) + "($|\\s)");
+        return completeWord.matcher(normalizedText).find();
+    }
+
+    private static Optional<Integer> romanToArabic(String value) {
+        String roman = value.toUpperCase(Locale.ROOT);
+        if (!VALID_ROMAN.matcher(roman).matches()) {
+            return Optional.empty();
+        }
+        int total = 0;
+        int previous = 0;
+        for (int index = roman.length() - 1; index >= 0; index--) {
+            int current = romanValue(roman.charAt(index));
+            total += current < previous ? -current : current;
+            previous = current;
+        }
+        return total > 0 && toRoman(total).equals(roman) ? Optional.of(total) : Optional.empty();
+    }
+
+    private static int romanValue(char value) {
+        return switch (value) {
+            case 'I' -> 1;
+            case 'V' -> 5;
+            case 'X' -> 10;
+            case 'L' -> 50;
+            case 'C' -> 100;
+            case 'D' -> 500;
+            case 'M' -> 1000;
+            default -> 0;
+        };
+    }
+
+    private static String toRoman(int value) {
+        int[] arabic = {1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1};
+        String[] roman = {"M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"};
+        StringBuilder result = new StringBuilder();
+        int remaining = value;
+        for (int index = 0; index < arabic.length; index++) {
+            while (remaining >= arabic[index]) {
+                result.append(roman[index]);
+                remaining -= arabic[index];
+            }
+        }
+        return result.toString();
+    }
+}

--- a/src/test/java/fr/abes/bestppn/model/tiebreak/CandidateDecisionKeyTest.java
+++ b/src/test/java/fr/abes/bestppn/model/tiebreak/CandidateDecisionKeyTest.java
@@ -1,0 +1,58 @@
+package fr.abes.bestppn.model.tiebreak;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CandidateDecisionKeyTest {
+
+    @Test
+    void compareDansLOrdreScoreSupportDiffuseurVolumeAnnee() {
+        CandidateDecisionKey supportFort = new CandidateDecisionKey(10, 2, 0, 0, 0);
+        CandidateDecisionKey diffuseurFort = new CandidateDecisionKey(10, 1, 2, 3, 3);
+        CandidateDecisionKey scoreFort = new CandidateDecisionKey(11, 0, 0, 0, 0);
+
+        assertTrue(supportFort.compareTo(diffuseurFort) > 0);
+        assertTrue(scoreFort.compareTo(supportFort) > 0);
+    }
+
+    @Test
+    void identifieUniquementLesContradictionsFortes() {
+        assertTrue(new CandidateDecisionKey(10, 0, 2, 3, 3).hasStrongContradiction());
+        assertTrue(new CandidateDecisionKey(10, 2, 2, 0, 3).hasStrongContradiction());
+        assertTrue(new CandidateDecisionKey(10, 2, 2, 3, 0).hasStrongContradiction());
+        assertFalse(new CandidateDecisionKey(10, 2, 0, 3, 3).hasStrongContradiction());
+    }
+
+    @Test
+    void exposeUneDecisionResolueOuIndecidable() {
+        CandidateDecisionKey key = new CandidateDecisionKey(10, 2, 1, 1, 1);
+        TieBreakDecision selected = TieBreakDecision.selected("123456789", Map.of("123456789", key), "SUPPORT");
+        TieBreakDecision unresolved = TieBreakDecision.unresolved(Map.of("123456789", key), "égalité");
+
+        assertTrue(selected.resolved());
+        assertEquals("123456789", selected.selectedPpn());
+        assertFalse(unresolved.resolved());
+        assertNull(unresolved.selectedPpn());
+    }
+
+    @Test
+    void detecteDesAnneesSudocContradictoires() {
+        CandidateMetadata metadata = new CandidateMetadata(
+                "123456789",
+                AccessMode.ONLINE,
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                Set.of(2021),
+                Set.of(2020, 2021),
+                List.of(),
+                false);
+
+        assertTrue(metadata.hasContradictoryYears());
+    }
+}

--- a/src/test/java/fr/abes/bestppn/service/BestPpnServiceTest.java
+++ b/src/test/java/fr/abes/bestppn/service/BestPpnServiceTest.java
@@ -9,6 +9,7 @@ import fr.abes.bestppn.model.dto.kafka.LigneKbartDto;
 import fr.abes.bestppn.model.dto.wscall.NoticeSummaryDto;
 import fr.abes.bestppn.model.dto.wscall.ResultWsSudocDto;
 import fr.abes.bestppn.model.entity.basexml.notice.NoticeXml;
+import fr.abes.bestppn.model.tiebreak.TieBreakDecision;
 import fr.abes.bestppn.utils.DESTINATION_TOPIC;
 import fr.abes.bestppn.utils.TYPE_SUPPORT;
 import fr.abes.bestppn.utils.Utils;
@@ -49,6 +50,9 @@ class BestPpnServiceTest {
     @MockitoBean
     WsService service;
 
+    @MockitoBean
+    BestPpnTieBreakerService tieBreakerService;
+
     @Value("classpath:143519379.xml")
     private Resource xmlFileNoticePrint;
 
@@ -72,6 +76,12 @@ class BestPpnServiceTest {
         this.noticePrint = mapper.readValue(
                 IOUtils.toString(new FileInputStream(xmlFileNoticePrint.getFile()), StandardCharsets.UTF_8),
                 NoticeXml.class);
+        Mockito.when(tieBreakerService.resolve(
+                        Mockito.any(),
+                        Mockito.anyString(),
+                        Mockito.anyMap()))
+                .thenReturn(TieBreakDecision.unresolved(
+                        Map.of(), "clés identiques"));
     }
 
     private LigneKbartDto createSerialKbart(String titleUrl) {
@@ -355,7 +365,8 @@ class BestPpnServiceTest {
         ppnElecResultList.put("100000001", 10);
         Set<String> ppnPrintResultList = new HashSet<>();
 
-        BestPpn result = bestPpnService.getBestPpnByScore(kbart, ppnElecResultList, ppnPrintResultList, false);
+        BestPpn result = bestPpnService.getBestPpnByScore(
+                kbart, "", ppnElecResultList, ppnPrintResultList, false);
         Assertions.assertEquals("100000001", result.getPpn());
         Assertions.assertEquals(DESTINATION_TOPIC.BEST_PPN_BACON, result.getDestination());
     }
@@ -369,7 +380,8 @@ class BestPpnServiceTest {
         ppnElecResultList.put("100000002", 10);
         Set<String> ppnPrintResultList = new HashSet<>();
 
-        BestPpn result = bestPpnService.getBestPpnByScore(kbart, ppnElecResultList, ppnPrintResultList, false);
+        BestPpn result = bestPpnService.getBestPpnByScore(
+                kbart, "", ppnElecResultList, ppnPrintResultList, false);
         Assertions.assertEquals("100000002", result.getPpn());
         Assertions.assertEquals(DESTINATION_TOPIC.BEST_PPN_BACON, result.getDestination());
     }
@@ -383,7 +395,8 @@ class BestPpnServiceTest {
         ppnElecResultList.put("100000002", 10);
         Set<String> ppnPrintResultList = new HashSet<>();
 
-        BestPpn result = bestPpnService.getBestPpnByScore(kbart, ppnElecResultList, ppnPrintResultList, true);
+        BestPpn result = bestPpnService.getBestPpnByScore(
+                kbart, "", ppnElecResultList, ppnPrintResultList, true);
         Assertions.assertEquals("", result.getPpn());
     }
 
@@ -398,7 +411,8 @@ class BestPpnServiceTest {
         ppnPrintResultList.add("100000001");
         ppnPrintResultList.add("100000002");
 
-        BestPpn result = bestPpnService.getBestPpnByScore(kbart, ppnElecResultList, ppnPrintResultList, true);
+        BestPpn result = bestPpnService.getBestPpnByScore(
+                kbart, "", ppnElecResultList, ppnPrintResultList, true);
         Assertions.assertEquals("", result.getPpn());
     }
 

--- a/src/test/java/fr/abes/bestppn/service/BestPpnServiceTieBreakTest.java
+++ b/src/test/java/fr/abes/bestppn/service/BestPpnServiceTieBreakTest.java
@@ -1,0 +1,122 @@
+package fr.abes.bestppn.service;
+
+import fr.abes.bestppn.exception.BestPpnException;
+import fr.abes.bestppn.kafka.TopicProducer;
+import fr.abes.bestppn.model.BestPpn;
+import fr.abes.bestppn.model.dto.kafka.LigneKbartDto;
+import fr.abes.bestppn.model.tiebreak.CandidateDecisionKey;
+import fr.abes.bestppn.model.tiebreak.TieBreakDecision;
+import fr.abes.bestppn.utils.DESTINATION_TOPIC;
+import fr.abes.bestppn.utils.TYPE_SUPPORT;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BestPpnServiceTieBreakTest {
+    @Mock
+    private WsService wsService;
+    @Mock
+    private TopicProducer topicProducer;
+    @Mock
+    private CheckUrlService checkUrlService;
+    @Mock
+    private BestPpnTieBreakerService tieBreakerService;
+
+    private BestPpnService service;
+    private LigneKbartDto kbart;
+
+    @BeforeEach
+    void setUp() {
+        service = new BestPpnService(
+                wsService, topicProducer, checkUrlService, tieBreakerService);
+        kbart = new LigneKbartDto();
+        kbart.setPublicationTitle("Titre");
+        kbart.setPublicationType("monograph");
+    }
+
+    @Test
+    void utiliseLePpnRetenuPourUneEgaliteMaximale() throws BestPpnException {
+        Map<String, Integer> candidates = ties();
+        CandidateDecisionKey selectedKey =
+                new CandidateDecisionKey(10, 2, 1, 1, 1);
+        when(tieBreakerService.resolve(kbart, "CAIRN", candidates))
+                .thenReturn(TieBreakDecision.selected(
+                        "100000001",
+                        Map.of("100000001", selectedKey),
+                        "SUPPORT"));
+
+        BestPpn result = service.getBestPpnByScore(
+                kbart, "CAIRN", candidates, Set.of(), false);
+
+        assertEquals("100000001", result.getPpn());
+        assertEquals(DESTINATION_TOPIC.BEST_PPN_BACON, result.getDestination());
+        assertEquals(TYPE_SUPPORT.ELECTRONIQUE, result.getTypeSupport());
+    }
+
+    @Test
+    void conserveLexceptionActuelleSiLarbitrageEchoue() {
+        Map<String, Integer> candidates = ties();
+        when(tieBreakerService.resolve(kbart, "CAIRN", candidates))
+                .thenReturn(TieBreakDecision.unresolved(
+                        Map.of(), "clés identiques"));
+
+        BestPpnException exception = assertThrows(
+                BestPpnException.class,
+                () -> service.getBestPpnByScore(
+                        kbart, "CAIRN", candidates, Set.of(), false));
+
+        assertTrue(exception.getMessage().startsWith(
+                "Plusieurs ppn électroniques ("));
+        assertTrue(exception.getMessage().contains(
+                ") ont le même score."));
+    }
+
+    @Test
+    void conserveLeBestPpnVideEnModeForceSiLarbitrageEchoue()
+            throws BestPpnException {
+        Map<String, Integer> candidates = ties();
+        when(tieBreakerService.resolve(kbart, "CAIRN", candidates))
+                .thenReturn(TieBreakDecision.unresolved(
+                        Map.of(), "clés identiques"));
+
+        BestPpn result = service.getBestPpnByScore(
+                kbart, "CAIRN", candidates, Set.of(), true);
+
+        assertEquals("", result.getPpn());
+        assertEquals(DESTINATION_TOPIC.BEST_PPN_BACON, result.getDestination());
+    }
+
+    @Test
+    void nappellePasLarbitragePourUnMaximumUnique()
+            throws BestPpnException {
+        Map<String, Integer> candidates = new LinkedHashMap<>();
+        candidates.put("100000001", 10);
+        candidates.put("100000002", 5);
+
+        BestPpn result = service.getBestPpnByScore(
+                kbart, "CAIRN", candidates, Set.of(), false);
+
+        assertEquals("100000001", result.getPpn());
+        verifyNoInteractions(tieBreakerService);
+    }
+
+    private static Map<String, Integer> ties() {
+        Map<String, Integer> candidates = new LinkedHashMap<>();
+        candidates.put("100000001", 10);
+        candidates.put("100000002", 10);
+        return candidates;
+    }
+}

--- a/src/test/java/fr/abes/bestppn/service/BestPpnTieBreakerFlowTest.java
+++ b/src/test/java/fr/abes/bestppn/service/BestPpnTieBreakerFlowTest.java
@@ -1,0 +1,228 @@
+package fr.abes.bestppn.service;
+
+import fr.abes.bestppn.model.dto.kafka.LigneKbartDto;
+import fr.abes.bestppn.model.entity.bacon.Provider;
+import fr.abes.bestppn.model.entity.basexml.notice.Controlfield;
+import fr.abes.bestppn.model.entity.basexml.notice.Datafield;
+import fr.abes.bestppn.model.entity.basexml.notice.NoticeXml;
+import fr.abes.bestppn.model.entity.basexml.notice.SubField;
+import fr.abes.bestppn.model.tiebreak.TieBreakDecision;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BestPpnTieBreakerFlowTest {
+    @Mock
+    private NoticeService noticeService;
+    @Mock
+    private ProviderService providerService;
+
+    private BestPpnTieBreakerService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new BestPpnTieBreakerService(
+                noticeService,
+                providerService,
+                new CandidateMetadataExtractor());
+    }
+
+    @Test
+    void supportEnLigneGagneContreCdRom() throws IOException {
+        LigneKbartDto kbart = kbart("serial");
+        notices(
+                notice("100000001", "Ressource en ligne", null, null, null, null),
+                notice("100000002", "CD-ROM", null, null, null, null));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertTrue(decision.resolved());
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals("SUPPORT", decision.reason());
+    }
+
+    @Test
+    void casReel164581340EstClasseCommeCdRom() throws IOException {
+        LigneKbartDto kbart = kbart("serial");
+        NoticeXml physical = notice(
+                "164581340", "( CD-ROM)", null, null, null, null);
+        physical.getControlfields().get(1).setValue("Obx3");
+        physical.getDatafields().add(
+                field("531", "#", "b", "(CD-ROM)"));
+        when(noticeService.getNoticeByPpn("100000001")).thenReturn(
+                notice("100000001", "Ressource en ligne", null, null, null, null));
+        when(noticeService.getNoticeByPpn("164581340")).thenReturn(physical);
+        Map<String, Integer> candidates = new LinkedHashMap<>();
+        candidates.put("100000001", 10);
+        candidates.put("164581340", 10);
+
+        TieBreakDecision decision = service.resolve(kbart, "", candidates);
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals(0, decision.keys().get("164581340").supportRank());
+    }
+
+    @Test
+    void diffuseur214Indicateur2DepartageLesNotices() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        Provider provider = new Provider("CAIRN");
+        provider.setDisplayName("Cairn.info");
+        when(providerService.findByProvider("CAIRN"))
+                .thenReturn(Optional.of(provider));
+        notices(
+                notice("100000001", "Ressource en ligne", "Cairn.info", null, null, null),
+                notice("100000002", "Ressource en ligne", "Autre diffuseur", null, null, null));
+
+        TieBreakDecision decision = service.resolve(kbart, "CAIRN", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals("DIFFUSEUR", decision.reason());
+    }
+
+    @Test
+    void volume200hDepartageLesNotices() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setMonographVolume("Part II");
+        notices(
+                notice("100000001", "Ressource en ligne", null, "Tome 2", null, null),
+                notice("100000002", "Ressource en ligne", null, "Tome 3", null, null));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals("VOLUME", decision.reason());
+    }
+
+    @Test
+    void titreDePartie200iDepartageLesNotices() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setPublicationTitle("Traité complet - Méthodes numériques");
+        notices(
+                notice("100000001", "Ressource en ligne", null, null, "Méthodes numériques", null),
+                notice("100000002", "Ressource en ligne", null, null, "Autre partie", null));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals("VOLUME", decision.reason());
+    }
+
+    @Test
+    void annee100Et214DepartageLesNotices() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setDateMonographPublishedOnline("2021-01-01");
+        kbart.setDateMonographPublishedPrint("2020");
+        notices(
+                notice("100000001", "Ressource en ligne", null, null, null, 2021),
+                notice("100000002", "Ressource en ligne", null, null, null, 2020));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals("ANNÉE", decision.reason());
+    }
+
+    private void notices(NoticeXml first, NoticeXml second) throws IOException {
+        when(noticeService.getNoticeByPpn("100000001")).thenReturn(first);
+        when(noticeService.getNoticeByPpn("100000002")).thenReturn(second);
+    }
+
+    private static LigneKbartDto kbart(String publicationType) {
+        LigneKbartDto kbart = new LigneKbartDto();
+        kbart.setPublicationType(publicationType);
+        kbart.setPublicationTitle("Titre");
+        return kbart;
+    }
+
+    private static Map<String, Integer> ties() {
+        Map<String, Integer> candidates = new LinkedHashMap<>();
+        candidates.put("100000001", 10);
+        candidates.put("100000002", 10);
+        return candidates;
+    }
+
+    private static NoticeXml notice(
+            String ppn,
+            String support,
+            String distributor,
+            String volume,
+            String partTitle,
+            Integer year) {
+        NoticeXml notice = new NoticeXml();
+        notice.setLeader("     nam0 22        450 ");
+        notice.setControlfields(List.of(
+                controlfield("001", ppn),
+                controlfield("008", "Oax3")));
+
+        List<Datafield> fields = new ArrayList<>();
+        fields.add(field("530", " ", "b", support));
+        if (distributor != null) {
+            fields.add(field("214", "2", "c", distributor));
+        }
+        if (volume != null || partTitle != null) {
+            List<String> titleValues = new ArrayList<>();
+            if (volume != null) {
+                titleValues.add("h");
+                titleValues.add(volume);
+            }
+            if (partTitle != null) {
+                titleValues.add("i");
+                titleValues.add(partTitle);
+            }
+            fields.add(field(
+                    "200", " ", titleValues.toArray(String[]::new)));
+        }
+        if (year != null) {
+            fields.add(field(
+                    "100",
+                    " ",
+                    "a",
+                    "20240723d" + year + "    m  y0frey50      ba"));
+            fields.add(field("214", "0", "d", "[" + year + "]"));
+        }
+        notice.setDatafields(fields);
+        return notice;
+    }
+
+    private static Controlfield controlfield(String tag, String value) {
+        Controlfield field = new Controlfield();
+        field.setTag(tag);
+        field.setValue(value);
+        return field;
+    }
+
+    private static Datafield field(
+            String tag,
+            String ind2,
+            String... codeValues) {
+        Datafield field = new Datafield();
+        field.setTag(tag);
+        field.setInd1(" ");
+        field.setInd2(ind2);
+        List<SubField> subFields = new ArrayList<>();
+        for (int index = 0; index < codeValues.length; index += 2) {
+            if (codeValues[index + 1] != null) {
+                SubField subField = new SubField();
+                subField.setCode(codeValues[index]);
+                subField.setValue(codeValues[index + 1]);
+                subFields.add(subField);
+            }
+        }
+        field.setSubFields(subFields);
+        return field;
+    }
+}

--- a/src/test/java/fr/abes/bestppn/service/BestPpnTieBreakerServiceTest.java
+++ b/src/test/java/fr/abes/bestppn/service/BestPpnTieBreakerServiceTest.java
@@ -1,0 +1,260 @@
+package fr.abes.bestppn.service;
+
+import fr.abes.bestppn.model.dto.kafka.LigneKbartDto;
+import fr.abes.bestppn.model.entity.bacon.Provider;
+import fr.abes.bestppn.model.entity.basexml.notice.NoticeXml;
+import fr.abes.bestppn.model.tiebreak.AccessMode;
+import fr.abes.bestppn.model.tiebreak.CandidateMetadata;
+import fr.abes.bestppn.model.tiebreak.TieBreakDecision;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BestPpnTieBreakerServiceTest {
+    @Mock
+    private NoticeService noticeService;
+    @Mock
+    private ProviderService providerService;
+    @Mock
+    private CandidateMetadataExtractor extractor;
+
+    private BestPpnTieBreakerService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new BestPpnTieBreakerService(noticeService, providerService, extractor);
+    }
+
+    @Test
+    void supportEstPrioritairePourUneSerie() throws IOException {
+        LigneKbartDto kbart = kbart("serial");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE));
+        candidate("100000002", metadata("100000002", AccessMode.UNKNOWN));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertTrue(decision.resolved());
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals("SUPPORT", decision.reason());
+    }
+
+    @Test
+    void diffuseurDepartageDeuxMonographies() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        Provider provider = provider("CAIRN", "Cairn.info");
+        when(providerService.findByProvider("CAIRN")).thenReturn(Optional.of(provider));
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of("cairn info"), Set.of(), Set.of(), Set.of(), Set.of()));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of("autre diffuseur"), Set.of(), Set.of(), Set.of(), Set.of()));
+
+        TieBreakDecision decision = service.resolve(kbart, "CAIRN", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals(2, decision.keys().get("100000001").distributorRank());
+        assertEquals(0, decision.keys().get("100000002").distributorRank());
+    }
+
+    @Test
+    void providerAbsentDeBaconResteNeutre() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        when(providerService.findByProvider("INCONNU")).thenReturn(Optional.empty());
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of("premier diffuseur"), Set.of(), Set.of(), Set.of(), Set.of()));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of("second diffuseur"), Set.of(), Set.of(), Set.of(), Set.of()));
+
+        TieBreakDecision decision = service.resolve(kbart, "INCONNU", ties());
+
+        assertFalse(decision.resolved());
+        assertEquals(1, decision.keys().get("100000001").distributorRank());
+        assertEquals(1, decision.keys().get("100000002").distributorRank());
+    }
+
+    @Test
+    void volumeExactDepartageDeuxMonographies() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setMonographVolume("Tome II");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of(), Set.of("2"), Set.of(), Set.of(), Set.of()));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of(), Set.of("3"), Set.of(), Set.of(), Set.of()));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals(3, decision.keys().get("100000001").volumeRank());
+        assertEquals(0, decision.keys().get("100000002").volumeRank());
+    }
+
+    @Test
+    void titreDePartieDepartageSansMonographVolume() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setPublicationTitle("Traité complet - Méthodes numériques");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of(), Set.of(), Set.of("methodes numeriques"), Set.of(), Set.of()));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of(), Set.of(), Set.of("autre partie"), Set.of(), Set.of()));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals(2, decision.keys().get("100000001").volumeRank());
+        assertEquals(1, decision.keys().get("100000002").volumeRank());
+    }
+
+    @Test
+    void anneeEnLigneEstPrioritaireSurAnneeImprimee() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setDateMonographPublishedOnline("2021-01-01");
+        kbart.setDateMonographPublishedPrint("2020");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of(), Set.of(), Set.of(), Set.of(2021), Set.of(2021)));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of(), Set.of(), Set.of(), Set.of(2020), Set.of(2020)));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertEquals("100000001", decision.selectedPpn());
+        assertEquals(3, decision.keys().get("100000001").yearRank());
+        assertEquals(2, decision.keys().get("100000002").yearRank());
+    }
+
+    @Test
+    void egaliteDeClesResteIndecidable() throws IOException {
+        LigneKbartDto kbart = kbart("serial");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertFalse(decision.resolved());
+        assertEquals("clés identiques", decision.reason());
+    }
+
+    @Test
+    void lectureXmlImpossibleConserveLegalite() throws IOException {
+        LigneKbartDto kbart = kbart("serial");
+        when(noticeService.getNoticeByPpn("100000001")).thenThrow(new IOException("base indisponible"));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertFalse(decision.resolved());
+        assertEquals("notice absente, supprimée ou illisible", decision.reason());
+        verify(noticeService, times(1)).getNoticeByPpn("100000001");
+        verify(noticeService, times(1)).getNoticeByPpn("100000002");
+    }
+
+    @Test
+    void supportPhysiqueInterditLaSelection() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        Provider provider = provider("CAIRN", "Cairn.info");
+        when(providerService.findByProvider("CAIRN")).thenReturn(Optional.of(provider));
+        candidate("100000001", metadata("100000001", AccessMode.PHYSICAL, Set.of("cairn info"), Set.of(), Set.of(), Set.of(), Set.of()));
+        candidate("100000002", metadata("100000002", AccessMode.PHYSICAL, Set.of("autre diffuseur"), Set.of(), Set.of(), Set.of(), Set.of()));
+
+        TieBreakDecision decision = service.resolve(kbart, "CAIRN", ties());
+
+        assertFalse(decision.resolved());
+        assertEquals("contradiction forte sur le meilleur candidat", decision.reason());
+    }
+
+    @Test
+    void volumeExplicitementIncompatibleInterditLaSelection() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setMonographVolume("2");
+        kbart.setDateMonographPublishedOnline("2021");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of(), Set.of("3"), Set.of(), Set.of(2021), Set.of(2021)));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of(), Set.of("4"), Set.of(), Set.of(2020), Set.of(2020)));
+
+        TieBreakDecision decision = service.resolve(kbart, "", ties());
+
+        assertFalse(decision.resolved());
+        assertEquals(0, decision.keys().get("100000001").volumeRank());
+    }
+
+    @Test
+    void anneeExplicitementIncompatibleInterditLaSelection() throws IOException {
+        LigneKbartDto kbart = kbart("monograph");
+        kbart.setDateMonographPublishedOnline("2021");
+        Provider provider = provider("CAIRN", "Cairn.info");
+        when(providerService.findByProvider("CAIRN")).thenReturn(Optional.of(provider));
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of("cairn info"), Set.of(), Set.of(), Set.of(2019), Set.of(2019)));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of("autre diffuseur"), Set.of(), Set.of(), Set.of(2018), Set.of(2018)));
+
+        TieBreakDecision decision = service.resolve(kbart, "CAIRN", ties());
+
+        assertFalse(decision.resolved());
+        assertEquals(0, decision.keys().get("100000001").yearRank());
+    }
+
+    @Test
+    void seriesIgnorentDiffuseurVolumeEtAnnee() throws IOException {
+        LigneKbartDto kbart = kbart("serial");
+        kbart.setMonographVolume("2");
+        kbart.setDateMonographPublishedOnline("2021");
+        candidate("100000001", metadata("100000001", AccessMode.ONLINE, Set.of("cairn info"), Set.of("2"), Set.of(), Set.of(2021), Set.of()));
+        candidate("100000002", metadata("100000002", AccessMode.ONLINE, Set.of("autre"), Set.of("3"), Set.of(), Set.of(2020), Set.of()));
+
+        TieBreakDecision decision = service.resolve(kbart, "CAIRN", ties());
+
+        assertFalse(decision.resolved());
+        assertEquals(1, decision.keys().get("100000001").distributorRank());
+        assertEquals(1, decision.keys().get("100000001").volumeRank());
+        assertEquals(1, decision.keys().get("100000001").yearRank());
+    }
+
+    private void candidate(String ppn, CandidateMetadata metadata) throws IOException {
+        NoticeXml notice = new NoticeXml();
+        when(noticeService.getNoticeByPpn(ppn)).thenReturn(notice);
+        when(extractor.extract(ppn, notice)).thenReturn(metadata);
+    }
+
+    private static LigneKbartDto kbart(String publicationType) {
+        LigneKbartDto kbart = new LigneKbartDto();
+        kbart.setPublicationType(publicationType);
+        kbart.setPublicationTitle("Titre");
+        return kbart;
+    }
+
+    private static Map<String, Integer> ties() {
+        Map<String, Integer> candidates = new LinkedHashMap<>();
+        candidates.put("100000001", 10);
+        candidates.put("100000002", 10);
+        return candidates;
+    }
+
+    private static CandidateMetadata metadata(String ppn, AccessMode accessMode) {
+        return metadata(ppn, accessMode, Set.of(), Set.of(), Set.of(), Set.of(), Set.of());
+    }
+
+    private static CandidateMetadata metadata(
+            String ppn,
+            AccessMode accessMode,
+            Set<String> distributors,
+            Set<String> volumeNumbers,
+            Set<String> partTitles,
+            Set<Integer> yearsFrom100,
+            Set<Integer> yearsFrom214) {
+        return new CandidateMetadata(
+                ppn,
+                accessMode,
+                distributors,
+                volumeNumbers,
+                partTitles,
+                yearsFrom100,
+                yearsFrom214,
+                List.of(),
+                false);
+    }
+
+    private static Provider provider(String code, String displayName) {
+        Provider provider = new Provider(code);
+        provider.setDisplayName(displayName);
+        return provider;
+    }
+}

--- a/src/test/java/fr/abes/bestppn/service/CandidateMetadataExtractorTest.java
+++ b/src/test/java/fr/abes/bestppn/service/CandidateMetadataExtractorTest.java
@@ -1,0 +1,146 @@
+package fr.abes.bestppn.service;
+
+import fr.abes.bestppn.model.entity.basexml.notice.Controlfield;
+import fr.abes.bestppn.model.entity.basexml.notice.Datafield;
+import fr.abes.bestppn.model.entity.basexml.notice.NoticeXml;
+import fr.abes.bestppn.model.entity.basexml.notice.SubField;
+import fr.abes.bestppn.model.tiebreak.AccessMode;
+import fr.abes.bestppn.model.tiebreak.CandidateMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CandidateMetadataExtractorTest {
+    private final CandidateMetadataExtractor extractor = new CandidateMetadataExtractor();
+
+    @Test
+    void extraitToutesLesMetadonneesUtiles() {
+        NoticeXml notice = notice(
+                field("530", " ", "b", "Ressource en ligne"),
+                field("214", "2", "c", "Cairn.info", "d", "[2021]"),
+                field("200", " ", "h", "Part II", "i", "Méthodes numériques"),
+                field("100", " ", "a", "20240723d2021    m  y0frey50      ba"));
+
+        CandidateMetadata metadata = extractor.extract("123456789", notice);
+
+        assertEquals(AccessMode.ONLINE, metadata.accessMode());
+        assertEquals(Set.of("cairn info"), metadata.distributors());
+        assertEquals(Set.of("2"), metadata.volumeNumbers());
+        assertEquals(Set.of("methodes numeriques"), metadata.partTitles());
+        assertEquals(Set.of(2021), metadata.yearsFrom100());
+        assertEquals(Set.of(2021), metadata.yearsFrom214());
+        assertTrue(metadata.evidence().contains("530$b=Ressource en ligne"));
+        assertFalse(metadata.unreadable());
+    }
+
+    @Test
+    void reconnaitUnSupportPhysiqueDansLesZonesDescriptives() {
+        NoticeXml notice = notice(
+                field("531", " ", "b", "CD-ROM"),
+                field("215", " ", "a", "1 disque optique numérique (DVD-ROM)"));
+
+        assertEquals(AccessMode.PHYSICAL, extractor.extract("123456789", notice).accessMode());
+    }
+
+    @Test
+    void conserveUnSupportHybrideCommeInconnu() {
+        NoticeXml notice = notice(
+                field("530", " ", "b", "Ressource en ligne"),
+                field("215", " ", "a", "1 CD-ROM"));
+
+        assertEquals(AccessMode.UNKNOWN, extractor.extract("123456789", notice).accessMode());
+    }
+
+    @Test
+    void neClassePasLaSeuleValeurODe008CommeAccesEnLigne() {
+        NoticeXml notice = notice();
+
+        assertEquals(AccessMode.UNKNOWN, extractor.extract("123456789", notice).accessMode());
+    }
+
+    @Test
+    void neConserveQueLes214QuiPortentLeSecondIndicateur2() {
+        NoticeXml notice = notice(
+                field("214", "0", "c", "Autre diffuseur"),
+                field("214", "2", "c", "Cairn.info"));
+
+        assertEquals(
+                Set.of("cairn info"),
+                extractor.extract("123456789", notice).distributors());
+    }
+
+    @Test
+    void extraitPlusieursAnnees214CommeDonneesContradictoires() {
+        NoticeXml notice = notice(
+                field("214", "0", "d", "DL 2020"),
+                field("214", "0", "d", "cop. 2021"));
+
+        CandidateMetadata metadata = extractor.extract("123456789", notice);
+
+        assertEquals(Set.of(2020, 2021), metadata.yearsFrom214());
+        assertTrue(metadata.hasContradictoryYears());
+    }
+
+    @Test
+    void marqueUneNoticeAbsenteOuSupprimeeCommeIllisible() {
+        assertTrue(extractor.extract("123456789", null).unreadable());
+
+        NoticeXml deleted = notice();
+        deleted.setLeader("     dam0 22        450 ");
+        assertTrue(extractor.extract("123456789", deleted).unreadable());
+    }
+
+    @Test
+    void tolereLesListesEtValeursNulles() {
+        NoticeXml notice = new NoticeXml();
+        notice.setLeader("     nam0 22        450 ");
+        notice.setControlfields(null);
+        Datafield malformedField = field("200", " ", "h", null);
+        List<SubField> malformedSubfields = new ArrayList<>(malformedField.getSubFields());
+        malformedSubfields.add(null);
+        malformedField.setSubFields(malformedSubfields);
+        List<Datafield> malformedDatafields = new ArrayList<>();
+        malformedDatafields.add(null);
+        malformedDatafields.add(malformedField);
+        notice.setDatafields(malformedDatafields);
+
+        CandidateMetadata metadata = extractor.extract("123456789", notice);
+
+        assertFalse(metadata.unreadable());
+        assertTrue(metadata.volumeNumbers().isEmpty());
+    }
+
+    private static NoticeXml notice(Datafield... fields) {
+        NoticeXml notice = new NoticeXml();
+        notice.setLeader("     nam0 22        450 ");
+        Controlfield ppn = new Controlfield();
+        ppn.setTag("001");
+        ppn.setValue("123456789");
+        Controlfield type = new Controlfield();
+        type.setTag("008");
+        type.setValue("Oax3");
+        notice.setControlfields(List.of(ppn, type));
+        notice.setDatafields(List.of(fields));
+        return notice;
+    }
+
+    private static Datafield field(String tag, String ind2, String... codeValues) {
+        Datafield field = new Datafield();
+        field.setTag(tag);
+        field.setInd1(" ");
+        field.setInd2(ind2);
+        List<SubField> subFields = new ArrayList<>();
+        for (int index = 0; index < codeValues.length; index += 2) {
+            SubField subField = new SubField();
+            subField.setCode(codeValues[index]);
+            subField.setValue(codeValues[index + 1]);
+            subFields.add(subField);
+        }
+        field.setSubFields(subFields);
+        return field;
+    }
+}

--- a/src/test/java/fr/abes/bestppn/utils/TieBreakNormalizerTest.java
+++ b/src/test/java/fr/abes/bestppn/utils/TieBreakNormalizerTest.java
@@ -1,0 +1,50 @@
+package fr.abes.bestppn.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TieBreakNormalizerTest {
+
+    @Test
+    void normaliseTexteSansPerdreLesChiffres() {
+        assertEquals("edition numero 2", TieBreakNormalizer.normalizeText("  Édition, numéro 2  "));
+    }
+
+    @Test
+    void normaliseLesVariantesDeVolume() {
+        assertEquals(Optional.of("2"), TieBreakNormalizer.normalizeVolume("02"));
+        assertEquals(Optional.of("2"), TieBreakNormalizer.normalizeVolume("Tome 2"));
+        assertEquals(Optional.of("2"), TieBreakNormalizer.normalizeVolume("Vol. 2"));
+        assertEquals(Optional.of("2"), TieBreakNormalizer.normalizeVolume("Part II"));
+        assertEquals(Optional.empty(), TieBreakNormalizer.normalizeVolume("IIII"));
+    }
+
+    @Test
+    void extraitUnVolumeUniquementAvecUnPrefixeDansLeTitre() {
+        assertEquals(Optional.of("12"), TieBreakNormalizer.extractVolumeFromTitle("Traité pratique, volume XII"));
+        assertEquals(Optional.empty(), TieBreakNormalizer.extractVolumeFromTitle("Les douze travaux"));
+    }
+
+    @Test
+    void extraitLaDate1DeLaZone100EtNonLaDateDeSaisie() {
+        assertEquals(OptionalInt.of(2021), TieBreakNormalizer.extractDate1From100("20240723d2021    m  y0frey50      ba"));
+        assertEquals(OptionalInt.empty(), TieBreakNormalizer.extractDate1From100("valeur courte"));
+    }
+
+    @Test
+    void extraitLesAnneesDesMentionsDePublication() {
+        assertEquals(OptionalInt.of(2021), TieBreakNormalizer.extractYear("DL 2021"));
+        assertEquals(Set.of(2020, 2021), TieBreakNormalizer.extractYears("cop. 2020-2021"));
+    }
+
+    @Test
+    void reconnaitUnCodeProviderCommeMotComplet() {
+        assertTrue(TieBreakNormalizer.containsWord("diffusion cairn info", "cairn"));
+        assertFalse(TieBreakNormalizer.containsWord("diffusion cairninfo", "cairn"));
+    }
+}


### PR DESCRIPTION
## Objet

Promouvoir sur l’environnement de test l’implémentation de [SOA-501](https://abes-esr.atlassian.net/browse/SOA-501), déjà validée et déployée en développement.

## Contenu

- arbitrage lexicographique des PPN ex æquo selon `SUPPORT → DIFFUSEUR → VOLUME → ANNÉE` ;
- garde-fous empêchant la sélection automatique d’un candidat présentant une contradiction forte ;
- intégration du moteur dans `BestPpnService` ;
- couverture unitaire et du flux complet de départage ;
- passage du projet en version `1.2.6-SNAPSHOT`.

## Validation avant promotion

- PR fonctionnelle #174 fusionnée dans `develop` ;
- build GitHub Actions de `develop` réussi ;
- image `develop-best-ppn-api` déployée et active sur `diplo2-dev` ;
- digest déployé identique au registre Docker ;
- API de développement accessible.

## Hors périmètre

La maintenance Avro de la PR #175 est encore en brouillon et n’est pas incluse dans cette promotion.

[SOA-501]: https://abes-esr.atlassian.net/browse/SOA-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ