### PR TITLE
Promotion test : déployer SOA-817

### DIFF
--- a/README-developpement.md
+++ b/README-developpement.md
@@ -52,7 +52,10 @@ Cette recherche de ppn(s) fait appel à des web services de l'API sudoc-api ([li
 1. via le `OnlineIdentifier` s'il est présent
 2. via le `PrintIndentifier` s'il est présent
 3. via le `TitleUrl` s'il est présent
-4. via le `DAT` (Date-Auteur-Titre) si les trois recherches précédentes n'ont données aucun résultat
+4. via le `DAT` (Date-Auteur-Titre) si les trois recherches précédentes n'ont donné aucun résultat :
+   - avec l'année de `date_monograph_published_online` en priorité ;
+   - si cet appel ne renvoie aucun PPN, avec l'année de `date_monograph_published_print`, lorsqu'elle est renseignée et différente de la première ;
+   - une même année n'est jamais interrogée deux fois et aucune requête `dat2ppn` n'est émise sans année exploitable.
 En fonction du web service utilisé, du type de support et du nombre de ppn, un score est attribué à chaque ppn.
 
 Après la recherche de ppn(s) terminée, la sélection du best ppn est réalisée via la méthode `getBestPpnByScore()`. Cette méthode détermine également le topic de destination.

--- a/src/main/java/fr/abes/bestppn/service/BestPpnService.java
+++ b/src/main/java/fr/abes/bestppn/service/BestPpnService.java
@@ -229,6 +229,11 @@ public class BestPpnService {
      * Recherche des monographies par année, auteur, titre et fournisseur
      * lorsque les autres stratégies n'ont retourné aucun candidat.
      *
+     * <p>L'année de publication en ligne est interrogée en priorité. Si elle
+     * ne retourne aucun PPN, l'année de publication imprimée est ensuite
+     * interrogée lorsqu'elle est renseignée et différente. Une même année
+     * n'est jamais recherchée deux fois.</p>
+     *
      * @param kbart ligne KBART fournissant les critères bibliographiques
      * @param ppnElecScoredList scores électroniques à compléter
      * @param ppnPrintResultList PPN imprimés à compléter
@@ -239,17 +244,22 @@ public class BestPpnService {
     private void feedPpnListFromDat(LigneKbartDto kbart, Map<String, Integer> ppnElecScoredList, Set<String> ppnPrintResultList, String providerName) throws IOException, URISyntaxException {
         log.debug(TECHNICAL, "Entrée dans dat2ppn");
         ResultWsSudocDto resultCallWs = new ResultWsSudocDto();
-        String dateParameter = "";
-        if (!kbart.getAnneeFromDate_monograph_published_online().isEmpty()) {
-            log.debug(TECHNICAL, "Appel dat2ppn :  date_monograph_published_online : {} / publication_title : {} auteur : {}", kbart.getDateMonographPublishedOnline(), kbart.getPublicationTitle(), kbart.getAuthor());
-            dateParameter = kbart.getAnneeFromDate_monograph_published_online();
-        } else if (!kbart.getAnneeFromDate_monograph_published_print().isEmpty()) {
-            log.debug(TECHNICAL, "Appel dat2ppn :  date_monograph_published_print : {} / publication_title : {} auteur : {}", kbart.getDateMonographPublishedPrint(), kbart.getPublicationTitle(), kbart.getAuthor());
-            dateParameter = kbart.getAnneeFromDate_monograph_published_print();
+        String onlineYear = kbart.getAnneeFromDate_monograph_published_online();
+        String printYear = kbart.getAnneeFromDate_monograph_published_print();
+        List<String> dateParameters = new ArrayList<>();
+        if (onlineYear != null && !onlineYear.isBlank()) {
+            dateParameters.add(onlineYear);
         }
-        if (!dateParameter.isEmpty()) {
+        if (printYear != null && !printYear.isBlank() && !printYear.equals(onlineYear)) {
+            dateParameters.add(printYear);
+        }
+        for (String dateParameter : dateParameters) {
+            log.debug(TECHNICAL, "Appel dat2ppn : année : {} / publication_title : {} auteur : {}", dateParameter, kbart.getPublicationTitle(), kbart.getAuthor());
             resultCallWs = service.callDat2Ppn(dateParameter, kbart.getAuthor(), kbart.getPublicationTitle(), providerName);
             log.info(FUNCTIONAL, resultCallWs.toString());
+            if (!resultCallWs.getPpns().isEmpty()) {
+                break;
+            }
         }
 
         List<NoticeSummaryDto> noticeElectronique = DtoHandlerService.getNoticeElectronique(resultCallWs);

--- a/src/test/java/fr/abes/bestppn/service/BestPpnServiceTest.java
+++ b/src/test/java/fr/abes/bestppn/service/BestPpnServiceTest.java
@@ -11,6 +11,7 @@ import fr.abes.bestppn.model.dto.wscall.ResultWsSudocDto;
 import fr.abes.bestppn.model.entity.basexml.notice.NoticeXml;
 import fr.abes.bestppn.model.tiebreak.TieBreakDecision;
 import fr.abes.bestppn.utils.DESTINATION_TOPIC;
+import fr.abes.bestppn.utils.PUBLICATION_TYPE;
 import fr.abes.bestppn.utils.TYPE_SUPPORT;
 import fr.abes.bestppn.utils.Utils;
 import org.apache.commons.io.IOUtils;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -95,6 +97,147 @@ class BestPpnServiceTest {
         kbart.setDateMonographPublishedPrint("DatePrint");
         kbart.setTitleUrl(titleUrl);
         return kbart;
+    }
+
+    private LigneKbartDto createMonographKbart(
+            String onlinePublicationDate,
+            String printPublicationDate) {
+        LigneKbartDto kbart = new LigneKbartDto();
+        kbart.setOnlineIdentifier("");
+        kbart.setPrintIdentifier("");
+        kbart.setPublicationType(PUBLICATION_TYPE.MONOGRAPH.toString());
+        kbart.setDateMonographPublishedOnline(onlinePublicationDate);
+        kbart.setDateMonographPublishedPrint(printPublicationDate);
+        kbart.setPublicationTitle("Titre");
+        kbart.setFirstAuthor("Auteur");
+        kbart.setTitleId("");
+        kbart.setTitleUrl("");
+        return kbart;
+    }
+
+    private ResultWsSudocDto createDatResult(String ppn) {
+        ResultWsSudocDto result = new ResultWsSudocDto();
+        result.setPpns(List.of(
+                new NoticeSummaryDto(
+                        ppn,
+                        TYPE_SUPPORT.ELECTRONIQUE,
+                        null,
+                        true)));
+        return result;
+    }
+
+    @Test
+    @DisplayName("dat2ppn utilise la date en ligne lorsqu'elle est seule")
+    void dat2PpnUsesOnlineYearWhenItIsTheOnlyPublicationDate()
+            throws IOException, BestPpnException, URISyntaxException {
+        String provider = "PROVIDER";
+        LigneKbartDto kbart = createMonographKbart("2024-06-15", null);
+        Mockito.when(service.callDat2Ppn(
+                        "2024", kbart.getAuthor(), kbart.getPublicationTitle(), provider))
+                .thenReturn(new ResultWsSudocDto());
+
+        bestPpnService.getBestPpn(kbart, provider, false);
+
+        Mockito.verify(service).callDat2Ppn(
+                "2024", kbart.getAuthor(), kbart.getPublicationTitle(), provider);
+    }
+
+    @Test
+    @DisplayName("dat2ppn utilise la date imprimée lorsqu'elle est seule")
+    void dat2PpnUsesPrintYearWhenItIsTheOnlyPublicationDate()
+            throws IOException, BestPpnException, URISyntaxException {
+        String provider = "PROVIDER";
+        LigneKbartDto kbart = createMonographKbart(null, "2023-01-10");
+        Mockito.when(service.callDat2Ppn(
+                        "2023", kbart.getAuthor(), kbart.getPublicationTitle(), provider))
+                .thenReturn(new ResultWsSudocDto());
+
+        bestPpnService.getBestPpn(kbart, provider, false);
+
+        Mockito.verify(service).callDat2Ppn(
+                "2023", kbart.getAuthor(), kbart.getPublicationTitle(), provider);
+    }
+
+    @Test
+    @DisplayName("dat2ppn n'interroge qu'une fois deux dates de la même année")
+    void dat2PpnSearchesOnlyOnceWhenPublicationYearsAreIdentical()
+            throws IOException, BestPpnException, URISyntaxException {
+        String provider = "PROVIDER";
+        LigneKbartDto kbart =
+                createMonographKbart("2024-06-15", "2024-01-10");
+        Mockito.when(service.callDat2Ppn(
+                        "2024", kbart.getAuthor(), kbart.getPublicationTitle(), provider))
+                .thenReturn(new ResultWsSudocDto());
+
+        bestPpnService.getBestPpn(kbart, provider, false);
+
+        Mockito.verify(service, Mockito.times(1)).callDat2Ppn(
+                "2024", kbart.getAuthor(), kbart.getPublicationTitle(), provider);
+    }
+
+    @Test
+    @DisplayName("dat2ppn s'arrête lorsque la date en ligne renvoie un PPN")
+    void dat2PpnStopsWhenOnlineYearReturnsAPpn()
+            throws IOException, BestPpnException, URISyntaxException {
+        String provider = "PROVIDER";
+        LigneKbartDto kbart =
+                createMonographKbart("2024-06-15", "2023-01-10");
+        Mockito.when(service.callDat2Ppn(
+                        "2024", kbart.getAuthor(), kbart.getPublicationTitle(), provider))
+                .thenReturn(createDatResult("200000001"));
+
+        BestPpn result = bestPpnService.getBestPpn(kbart, provider, false);
+
+        Mockito.verify(service).callDat2Ppn(
+                "2024", kbart.getAuthor(), kbart.getPublicationTitle(), provider);
+        Mockito.verify(service, Mockito.never()).callDat2Ppn(
+                "2023", kbart.getAuthor(), kbart.getPublicationTitle(), provider);
+        Assertions.assertEquals("200000001", result.getPpn());
+    }
+
+    @Test
+    @DisplayName("dat2ppn essaie la date imprimée lorsque la date en ligne ne renvoie aucun PPN")
+    void dat2PpnUsesPrintYearWhenOnlineYearReturnsNoPpn()
+            throws IOException, BestPpnException, URISyntaxException {
+        String provider = "PROVIDER";
+        LigneKbartDto kbart =
+                createMonographKbart("2024-06-15", "2023-01-10");
+
+        Mockito.when(service.callDat2Ppn(
+                        "2024", kbart.getAuthor(), kbart.getPublicationTitle(), provider))
+                .thenReturn(new ResultWsSudocDto());
+        Mockito.when(service.callDat2Ppn(
+                        "2023", kbart.getAuthor(), kbart.getPublicationTitle(), provider))
+                .thenReturn(createDatResult("200000002"));
+
+        BestPpn result = bestPpnService.getBestPpn(kbart, provider, false);
+
+        InOrder inOrder = Mockito.inOrder(service);
+        inOrder.verify(service).callDat2Ppn(
+                "2024", kbart.getAuthor(), kbart.getPublicationTitle(), provider);
+        inOrder.verify(service).callDat2Ppn(
+                "2023", kbart.getAuthor(), kbart.getPublicationTitle(), provider);
+        Assertions.assertEquals("200000002", result.getPpn());
+    }
+
+    @Test
+    @DisplayName("dat2ppn n'est pas appelé lorsqu'aucune date n'est exploitable")
+    void dat2PpnIsNotCalledWhenNoPublicationDateIsUsable()
+            throws IOException, BestPpnException, URISyntaxException {
+        String provider = "PROVIDER";
+        LigneKbartDto kbart = createMonographKbart(null, null);
+
+        BestPpn result = bestPpnService.getBestPpn(kbart, provider, false);
+
+        Mockito.verify(service, Mockito.never()).callDat2Ppn(
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any());
+        Assertions.assertNull(result.getPpn());
+        Assertions.assertEquals(
+                DESTINATION_TOPIC.NO_PPN_FOUND_SUDOC,
+                result.getDestination());
     }
 
     @Test


### PR DESCRIPTION
## Objet
Promotion de SOA-817 vers l'environnement test (`main`).

## Contenu
- enchaînement de `dat2ppn` sur la date en ligne puis la date imprimée ;
- absence de second appel si la première recherche aboutit ou si les années sont identiques ;
- conservation du filtrage provider, du classement et du départage SOA-501 ;
- ajout des six cas de tests unitaires et mise à jour de la documentation développeur.

## Vérifications
- 84 tests exécutés, 0 échec, 0 erreur ;
- workflow `develop` réussi : https://github.com/abes-esr/best-ppn-api/actions/runs/30081808410 ;
- image `develop-best-ppn-api` redéployée automatiquement sur diplo2-dev ;
- nouveau conteneur actif et Swagger accessible en HTTP 200.